### PR TITLE
Respect error_reporting and support error suppression using @-operator.

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -189,11 +189,13 @@ class Run
      */
     public function handleError($level, $message, $file = null, $line = null)
     {
-        $this->handleException(
-            new ErrorException(
-                $message, $level, 0, $file, $line
-            )
-        );
+        if ($level & error_reporting()) {
+            $this->handleException(
+                new ErrorException(
+                    $message, $level, 0, $file, $line
+                )
+            );
+        }
     }
 
     /**

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -218,4 +218,51 @@ class RunTest extends TestCase
 
         $run->handleException($this->getException());
     }
+
+    /**
+     * Test error suppression using @ operator.
+     */
+    public function testErrorSuppression()
+    {
+        $run = $this->getRunInstance();
+        $run->register();
+
+        $handler = $this->getHandler();
+        $run->pushHandler($handler);
+
+        $test = $this;
+        $handler
+            ->shouldReceive('handle')
+            ->andReturnUsing(function () use($test) {
+                $test->fail('$handler should not be called, error not suppressed');
+            })
+        ;
+
+        @trigger_error("Test error suppression");
+    }
+
+    /**
+     * Test to make sure that error_reporting is respected.
+     */
+    public function testErrorReporting()
+    {
+        $run = $this->getRunInstance();
+        $run->register();
+
+        $handler = $this->getHandler();
+        $run->pushHandler($handler);
+
+        $test = $this;
+        $handler
+            ->shouldReceive('handle')
+            ->andReturnUsing(function () use($test) {
+                $test->fail('$handler should not be called, error_reporting not respected');
+            })
+        ;
+
+        $oldLevel = error_reporting(E_ALL ^ E_USER_NOTICE);
+        trigger_error("Test error reporting", E_USER_NOTICE);
+        error_reporting($oldLevel);
+    }
+
 }


### PR DESCRIPTION
Without respecting error_reporting() there is no way to ignore errors (including warnings and notices) being caught by the handler. By checking if the error level is enabled by the current error_reporting level, we can chose what errors to ignore.

Some libraries depend on the @-operator and the change suggested here will make error-suppression using the @-operator work nicely since that will set error_reporting = 0.
