### PR TITLE
Only register Whoops as Exception handler if debug

### DIFF
--- a/src/Whoops/Provider/Illuminate/WhoopsServiceProvider.php
+++ b/src/Whoops/Provider/Illuminate/WhoopsServiceProvider.php
@@ -32,8 +32,10 @@ class WhoopsServiceProvider extends ServiceProvider {
             return $run->pushHandler($app['whoops.handler']);
         });
 
-        $app->error(function($e) use ($app) {
-            $app['whoops']->handleException($e);
-        });
+        if ($app['config']->get('app.debug')) {
+            $app->error(function($e) use ($app) {
+                $app['whoops']->handleException($e);
+            });
+        }
     }
 }


### PR DESCRIPTION
In Laravel there is a `debug` option in the `app.php` file.
Whoops shouldn't register itself as Exception handler if this option is false.
