### PR TITLE
Don't throw away the first frame, without making sure the second frame has a filename and linenumber.

### DIFF
--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -67,7 +67,7 @@ class Inspector
             // get rid of the last, which matches the handleError method,
             // and do not add the current exception to trace. We ensure that
             // the next frame does have a filename / linenumber, though.
-            if($this->exception instanceof ErrorException) {
+            if($this->exception instanceof ErrorException && empty($frames[1]['line'])) {
                 $frames[1] = $frames[1] + $frames[0];
                 array_shift($frames);
             } else {


### PR DESCRIPTION
If you're using Whoops to catch notices like "undefined variable", the second frame does not have a filename/linenumber:

![Screen Shot 2013-03-23 at 10 58 59 AM](https://f.cloud.github.com/assets/1833361/293679/9bfd43ec-93a0-11e2-9f16-80bd194d1fa3.png)

There's probably a good reason why PHP's backtrace does this, but in this case it causes an issue. If we throw the first away, the first item in the list can't show the matching code: 

![Screen Shot 2013-03-23 at 10 48 46 AM](https://f.cloud.github.com/assets/1833361/293680/b58f54ee-93a0-11e2-8bf8-b7bcab6607cc.png)

This patch merges `$frames[0]` and `$frames[1]`, before removing it, making sure that the first item in the list can show the matching code: 

![Screen Shot 2013-03-23 at 10 50 04 AM](https://f.cloud.github.com/assets/1833361/293682/dd915802-93a0-11e2-9b74-f05dc7b730a7.png)
