### PR TITLE
Added response status code for Laravel 4

### DIFF
--- a/src/Whoops/Provider/Illuminate/WhoopsServiceProvider.php
+++ b/src/Whoops/Provider/Illuminate/WhoopsServiceProvider.php
@@ -34,7 +34,12 @@ class WhoopsServiceProvider extends ServiceProvider {
 
         if ($app['config']->get('app.debug')) {
             $app->error(function($e) use ($app) {
+
+                // TODO solve this with Illuminate\Http\Response
+                header('HTTP/1.0 500 Internal Server Error', true, 500);
+
                 $app['whoops']->handleException($e);
+                
             });
         }
     }


### PR DESCRIPTION
Included your propose concerning the 500 status code. (https://github.com/filp/whoops/pull/8)

In fact this commit doesn't feel right since I wanted to use the Response class provided by Laravel.

Would it be possible for you instead of printing directly just returning the html markup? So I could make a HTTP response with that.

Instead of:

``` php
            $app->error(function($e) use ($app) {

                // TODO solve this with Illuminate\Http\Response
                header('HTTP/1.0 500 Internal Server Error', true, 500);

                $app['whoops']->handleException($e);

            });
```

Better:

``` php
            $app->error(function($e) use ($app) {

                $html =  $app['whoops']->handleException($e);
                $response = Response::make($html, 500);

                return $response;

            });
```
