### PR TITLE
Wrong code showed when exceptions occours in the first 8 lines

### DIFF
--- a/src/Whoops/Exception/Frame.php
+++ b/src/Whoops/Exception/Frame.php
@@ -161,7 +161,9 @@ class Frame
             {
                 $start  = (int) $start;
                 $length = (int) $length;
-
+                if ($start < 0) {
+                    $start = 0;
+                }
                 if($length <= 0) {
                     throw new InvalidArgumentException(
                         "\$length($length) cannot be lower or equal to 0"


### PR DESCRIPTION
If a exception its thrown on the first 8 lines, the code shown its from the end of the source file (because array_slice starts at the end when its provided with negative numbers).
