### PR TITLE
Zend Framework 2 Integration

### DIFF
--- a/src/Whoops/Provider/Zend/ExceptionStrategy.php
+++ b/src/Whoops/Provider/Zend/ExceptionStrategy.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * ZF2 Integration for Whoops
+ * @author Balázs Németh <zsilbi@zsilbi.hu>
+ */
+
+namespace Whoops\Provider\Zend;
+
+use Whoops\Run;
+
+use Zend\Mvc\View\Http\ExceptionStrategy as BaseExceptionStrategy;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Application;
+
+class ExceptionStrategy extends BaseExceptionStrategy {
+
+    protected $run;
+
+    public function __construct(Run $run) {
+        $this->run = $run;
+        return $this;
+    }
+
+    public function prepareExceptionViewModel(MvcEvent $event) {
+        // Do nothing if no error in the event
+        $error = $event->getError();
+        if (empty($error)) {
+            return;
+        }
+
+        // Do nothing if the result is a response object
+        $result = $event->getResult();
+        if ($result instanceof Response) {
+            return;
+        }
+
+        switch ($error) {
+            case Application::ERROR_CONTROLLER_NOT_FOUND:
+            case Application::ERROR_CONTROLLER_INVALID:
+            case Application::ERROR_ROUTER_NO_MATCH:
+                // Specifically not handling these
+                return;
+
+            case Application::ERROR_EXCEPTION:
+            default:
+                $response = $event->getResponse();
+                if (!$response || $response->getStatusCode() === 200) {
+                    header('HTTP/1.0 500 Internal Server Error', true, 500);
+                }
+                ob_clean();
+                $this->run->handleException($event->getParam('exception'));
+                break;
+        }
+    }
+
+}

--- a/src/Whoops/Provider/Zend/Module.php
+++ b/src/Whoops/Provider/Zend/Module.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * ZF2 Integration for Whoops
+ * @author Balázs Németh <zsilbi@zsilbi.hu>
+ * 
+ * The Whoops directory should be added as a module to ZF2 (/vendor/Whoops)
+ * 
+ * Whoops must be added as the first module
+ * For example:
+ *   'modules' => array(
+ *       'Whoops',
+ *       'Application',
+ *   ),
+ * 
+ * This file should be moved next to Whoops/Run.php (/vendor/Whoops/Module.php)
+ * 
+ */
+
+namespace Whoops;
+
+use Whoops\Run;
+use Whoops\Provider\Zend\ExceptionStrategy;
+use Whoops\Provider\Zend\RouteNotFoundStrategy;
+use Whoops\Handler\JsonResponseHandler;
+use Whoops\Handler\PrettyPageHandler;
+use Zend\EventManager\EventInterface;
+use Zend\Console\Request as ConsoleRequest;
+
+class Module {
+
+    protected $run;
+
+    public function onBootstrap(EventInterface $event) {
+        $prettyPageHandler = new PrettyPageHandler();
+
+        $this->run = new Run();
+        $this->run->register();
+        $this->run->pushHandler($prettyPageHandler);
+
+        $this->attachListeners($event);
+    }
+
+    public function getAutoloaderConfig() {
+        return array(
+            'Zend\Loader\StandardAutoloader' => array(
+                'namespaces' => array(
+                    __NAMESPACE__ => __DIR__,
+                ),
+            ),
+        );
+    }
+
+    private function attachListeners(EventInterface $event) {
+        $request = $event->getRequest();
+        $application = $event->getApplication();
+        $services = $application->getServiceManager();
+        $events = $application->getEventManager();
+        $config = $services->get('Config');
+
+        //Display exceptions based on configuration and console mode
+        if ($request instanceof ConsoleRequest || empty($config['view_manager']['display_exceptions']))
+            return;
+
+        $jsonHandler = new JsonResponseHandler();
+
+        if (!empty($config['view_manager']['json_exceptions']['show_trace'])) {
+            //Add trace to the JSON output 
+            $jsonHandler->addTraceToOutput(true);
+        }
+
+        if (!empty($config['view_manager']['json_exceptions']['ajax_only'])) {
+            //Only return JSON response for AJAX requests
+            $jsonHandler->onlyForAjaxRequests(true);
+        }
+        
+        if (!empty($config['view_manager']['json_exceptions']['display'])) {
+            //Turn on JSON handler
+            $this->run->pushHandler($jsonHandler);
+        }
+
+        //Attach the Whoops ExceptionStrategy
+        $exceptionStrategy = new ExceptionStrategy($this->run);
+        $exceptionStrategy->attach($events);
+
+        //Attach the Whoops RouteNotFoundStrategy
+        $routeNotFoundStrategy = new RouteNotFoundStrategy($this->run);
+        $routeNotFoundStrategy->attach($events);
+
+        //Detach default ExceptionStrategy
+        $services->get('Zend\Mvc\View\Http\ExceptionStrategy')->detach($events);
+
+        //Detach default RouteNotFoundStrategy
+        $services->get('Zend\Mvc\View\Http\RouteNotFoundStrategy')->detach($events);
+    }
+
+}

--- a/src/Whoops/Provider/Zend/RouteNotFoundStrategy.php
+++ b/src/Whoops/Provider/Zend/RouteNotFoundStrategy.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * ZF2 Integration for Whoops
+ * @author Balázs Németh <zsilbi@zsilbi.hu>
+ */
+
+namespace Whoops\Provider\Zend;
+
+use Whoops\Run;
+
+use Zend\Mvc\View\Http\RouteNotFoundStrategy as BaseRouteNotFoundStrategy;
+use Zend\Mvc\MvcEvent;
+use Zend\Stdlib\ResponseInterface as Response;
+use Zend\View\Model\ViewModel;
+
+class RouteNotFoundStrategy extends BaseRouteNotFoundStrategy {
+
+    protected $run;
+    
+    public function __construct(Run $run) {
+        $this->run = $run;
+    }
+    
+    public function prepareNotFoundViewModel(MvcEvent $e) {
+        $vars = $e->getResult();
+        if ($vars instanceof Response) {
+            // Already have a response as the result
+            return;
+        }
+
+        $response = $e->getResponse();
+        if ($response->getStatusCode() != 404) {
+            // Only handle 404 responses
+            return;
+        }
+
+        if (!$vars instanceof ViewModel) {
+            $model = new ViewModel();
+            if (is_string($vars)) {
+                $model->setVariable('message', $vars);
+            } else {
+                $model->setVariable('message', 'Page not found.');
+            }
+        } else {
+            $model = $vars;
+            if ($model->getVariable('message') === null) {
+                $model->setVariable('message', 'Page not found.');
+            }
+        }
+        // If displaying reasons, inject the reason
+        $this->injectNotFoundReason($model, $e);
+
+        // If displaying exceptions, inject
+        $this->injectException($model, $e);
+
+        // Inject controller if we're displaying either the reason or the exception
+        $this->injectController($model, $e);
+        
+        ob_clean();
+        
+        throw new \Exception($model->getVariable('message') . ' ' . $model->getVariable('reason'));
+    }
+
+}

--- a/src/Whoops/Provider/Zend/module.config.example.php
+++ b/src/Whoops/Provider/Zend/module.config.example.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * ZF2 Integration for Whoops
+ * @author Balázs Németh <zsilbi@zsilbi.hu>
+ * 
+ * Example controller configuration
+ */
+
+return array(
+    'view_manager' => array(
+        'display_not_found_reason' => true,
+        'display_exceptions' => true,
+        'json_exceptions' => array(
+            'display' => true,
+            'ajax_only' => true,
+            'show_trace' => true
+        )
+    ),
+);


### PR DESCRIPTION
Response for issue #30

Instructions:
- add Whoops as a module to you app (/vendor/Whoops)
- Whoops must be the first module:

``` php
'modules' => array(
        'Whoops',
        'Application'
   )
```
- move Module.php from /Whoops/Provider/Zend/Module.php to /Whoops/Module.php
- use optional configurations in your controller config: 

``` php
return array(
    'view_manager' => array(
        'display_not_found_reason' => true,
        'display_exceptions' => true,
        'json_exceptions' => array(
            'display' => true,
            'ajax_only' => true,
            'show_trace' => true
        )
    ),
);
```
- NOTE: ob_clean(); is used to remove previous output, so you may use ob_start(); at the beginning of your app (index.php)
