### PR TITLE
Add automatic removal of any previous output buffering.

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -144,6 +144,9 @@ class Run
      */
     public function handleException(Exception $exception)
     {
+        // Remove any previous output
+        ob_get_level() and ob_end_clean();
+
         // Walk the registered handlers in the reverse order
         // they were registered, and pass off the exception
         $inspector = $this->getInspector($exception);


### PR DESCRIPTION
Hi @filp, this is what I had in mind [here](https://github.com/filp/whoops/issues/33#issuecomment-16573928).

Might be good if @taylorotwell had a peak to make sure it doesn't mess up his Laravel 4 [implemenation](https://github.com/laravel/framework/blob/64f3a79aae254b71550a8097880f0b0e09062d24/src/Illuminate/Exception/ExceptionServiceProvider.php).
