### PR TITLE
Use correct function for joining arrays

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -198,7 +198,7 @@ class PrettyPageHandler extends Handler
         if(!is_callable($editor) && !isset($this->editors[$editor])) {
             throw new InvalidArgumentException(
                 "Unknown editor identifier: $editor. Known editors:" .
-                array_join(",", array_keys($this->editors))
+                implode(",", array_keys($this->editors))
             );
         }
 


### PR DESCRIPTION
When I was trying to use Whoops - I managed to typo the editor - and was thrown back this error:-

`( ! ) Fatal error: Call to undefined function Whoops\Handler\array_join() in /vagrant/vendor/filp/whoops/src/Whoops/Handler/PrettyPageHandler.php on line 201`

The function that should be used is `implode()` (aka `join()`).
