### PR TITLE
Make sure 'whoops' error screen displays at top-left.

### DIFF
--- a/src/Whoops/Resources/pretty-page.css
+++ b/src/Whoops/Resources/pretty-page.css
@@ -17,6 +17,8 @@ body {
     position: fixed;
     margin: 0;
     padding: 0;
+    left: 0;
+    top: 0;
 }
 
 .branding {
@@ -73,6 +75,7 @@ header {
   overflow: auto;
   float: left;
   width: 30%;
+  background: #FFF;
 }
   .frame {
     padding: 14px;


### PR DESCRIPTION
If the page's output has already been started before whoops intercepts an error, the whoops error screen might be positioned outside of the viewport. You can't see it then, because of the `position: fixed`. By adding a `top: 0; left: 0;`, we ensure that it's visible. 
