### PR TITLE
Remove any data already in the output buffers before writing output.

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -194,6 +194,8 @@ class Run
         // ($handlerResponse will be the response from the last queried handler)
         // and if so, try to quit execution.
         if($this->allowQuit()) {
+            // Clean all output buffers before writing output
+            while (ob_get_level() > 0) ob_end_clean();
             echo $output;
             exit;
         } else {


### PR DESCRIPTION
`Whoops\Run#handleException()` now removes any data in **all** output buffers before writing the output, so the exception is shown full screen. It is to the end user whether to clean the buffers or not when `allowQuit` is false.
