### PR TITLE
Fixes issue where the wrong line gets highlighted

### DIFF
--- a/src/Whoops/Resources/pretty-template.php
+++ b/src/Whoops/Resources/pretty-template.php
@@ -83,6 +83,7 @@
 
                     // the $line is 1-indexed, we nab -1 where needed to account for this
                     $range = $frame->getFileLines($line - 8, 10);
+                    $range = array_map(function($line){ return empty($line) ? ' ' : $line;}, $range);
                     $start = key($range) + 1;
                     $code  = join("\n", $range);
                   ?>


### PR DESCRIPTION
Whoops sometimes highlights the wrong line because of a bug in "prettyprint".  This change fixes the issue by replacing empty lines with a space.
