### PR TITLE
On shutdown do not handle errors that can be handled by the registered e...

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -366,13 +366,30 @@ class Run
      */
     public function handleShutdown()
     {
-        if($error = error_get_last()) {
-            $this->handleError(
-                $error["type"],
-                $error["message"],
-                $error["file"],
-                $error["line"]
-            );
+        if ($error = error_get_last()) {
+
+            if (
+                in_array(
+                    $error['type'],
+                    array(
+                        E_ERROR,
+                        E_PARSE,
+                        E_CORE_ERROR,
+                        E_CORE_WARNING,
+                        E_COMPILE_ERROR,
+                        E_COMPILE_WARNING
+                    )
+                ) || (
+                    $error['type'] === E_STRICT && $error['file'] === __FILE__
+                )
+            ) {
+                $this->handleError(
+                    $error['type'],
+                    $error['message'],
+                    $error['file'],
+                    $error['line']
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
...rror handler.

We do this, because we are not able to inspect the error control operator examining
the output of error_get_last().

@see http://php.net/manual/en/language.operators.errorcontrol.php
@see http://www.php.net/manual/en/function.set-error-handler.php
