### PR TITLE
Workaround PHP bug 42098, autoload in strict errors

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -97,6 +97,13 @@ class Run
     public function register()
     {
         if(!$this->isRegistered) {
+            // Workaround PHP bug 42098
+            // https://bugs.php.net/bug.php?id=42098
+            class_exists('\\Whoops\\Exception\\ErrorException');
+            class_exists('\\Whoops\\Exception\\FrameCollection');
+            class_exists('\\Whoops\\Exception\\Frame');
+            class_exists('\\Whoops\\Exception\\Inspector');
+
             set_error_handler(array($this, self::ERROR_HANDLER));
             set_exception_handler(array($this, self::EXCEPTION_HANDLER));
             register_shutdown_function(array($this, self::SHUTDOWN_HANDLER));


### PR DESCRIPTION
_Previously https://github.com/filp/whoops/issues/69._

[PHP bug 42098](https://bugs.php.net/bug.php?id=42098) prevents autoloading Whoops classes on strict warnings.

As a result, instead of seeing a strict warning, a user of Whoops library sees `Class \Whoops\Exception\ErrorException does not exist` without any traceback, because it is a fatal error.

Given that PHP devs, as usual, have marked the bug as "Not a bug", I suggest to add a tiny workaround to Whoops to pre-autoload required classes to handle a strict warning:

```
class_exists('\\Whoops\\Exception\\ErrorException');
class_exists('\\Whoops\\Exception\\FrameCollection');
class_exists('\\Whoops\\Exception\\Frame');
class_exists('\\Whoops\\Exception\\Inspector');
```
