### PR TITLE
silenceErrorsInPaths

### DIFF
--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -296,6 +296,30 @@ class RunTest extends TestCase
     }
 
     /**
+     * @covers Whoops\Run::silenceErrorsInPaths
+     */
+    public function testSilenceErrorsInPaths()
+    {
+        $run = $this->getRunInstance();
+        $run->register();
+
+        $handler = $this->getHandler();
+        $run->pushHandler($handler);
+
+        $test = $this;
+        $handler
+            ->shouldReceive('handle')
+            ->andReturnUsing(function () use($test) {
+                $test->fail('$handler should not be called, silenceErrorsInPaths not respected');
+            })
+        ;
+
+        $run->silenceErrorsInPaths('@^'.preg_quote(__FILE__).'$@', E_USER_NOTICE);
+        trigger_error('Test', E_USER_NOTICE);
+        $this->assertTrue(true);
+    }
+
+    /**
      * @covers Whoops\Run::handleException
      * @covers Whoops\Run::writeToOutput
      */


### PR DESCRIPTION
Sometimes one needs to include some old code that's full of old school warnings.

If it's one's own code, one could add `error_reporting` statements in it.
But this does not work if there are many old callables (can't put an `error_reporting` into every one of them),
as well as it does not if the old code is 3rd party.

What's left? Modifying Whoops a tiny bit!
A simple test included.
