### PR TITLE
Fix incomplete tests

### DIFF
--- a/tests/Whoops/Handler/PrettyPageHandlerTest.php
+++ b/tests/Whoops/Handler/PrettyPageHandlerTest.php
@@ -43,6 +43,9 @@ class PrettyPageHandlerTest extends TestCase
         ob_start();
         $run->handleException($this->getException());
         ob_get_clean();
+
+        // Reached the end without errors
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -247,6 +247,9 @@ class RunTest extends TestCase
         ;
 
         $run->handleException($this->getException());
+
+        // Reached the end without errors
+        $this->assertTrue(true);
     }
 
     /**
@@ -269,6 +272,9 @@ class RunTest extends TestCase
         ;
 
         @trigger_error("Test error suppression");
+
+        // Reached the end without errors
+        $this->assertTrue(true);
     }
 
     /**
@@ -293,6 +299,9 @@ class RunTest extends TestCase
         $oldLevel = error_reporting(E_ALL ^ E_USER_NOTICE);
         trigger_error("Test error reporting", E_USER_NOTICE);
         error_reporting($oldLevel);
+
+        // Reached the end without errors
+        $this->assertTrue(true);
     }
 
     /**


### PR DESCRIPTION
When unit testing changes, it annoys that phpunit reports 4 incomplete tests.
It would be an otherwise useful warning, but in these cases the tests are actually complete.

There is `$this->fail()`, but no `$this->succeed()`.
I think that my tiny pull request is better than without it.
What do you think? :)
