### PR TITLE
Allow catching PHP errors

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -353,11 +353,7 @@ class Run
                     return true;
                 }
             }
-            $this->handleException(
-                new ErrorException(
-                    $message, $level, 0, $file, $line
-                )
-            );
+            throw new ErrorException($message, $level, 0, $file, $line);
         }
     }
 

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -279,6 +279,33 @@ class RunTest extends TestCase
         $this->assertTrue(true);
     }
 
+    public function testErrorCatching()
+    {
+        $run = $this->getRunInstance();
+        $run->register();
+
+        $handler = $this->getHandler();
+        $run->pushHandler($handler);
+
+        $test = $this;
+        $handler
+            ->shouldReceive('handle')
+            ->andReturnUsing(function () use($test) {
+                $test->fail('$handler should not be called error should be caught');
+            })
+        ;
+
+        try {
+            trigger_error(E_USER_NOTICE, 'foo');
+            $this->fail('Should not continue after error thrown');
+        } catch (\ErrorException $e) {
+            // Do nothing
+            $this->assertTrue(true);
+            return;
+        }
+        $this->fail('Should not continue here, should have been caught.');
+    }
+
     /**
      * Test to make sure that error_reporting is respected.
      */


### PR DESCRIPTION
It was strange that you called handleError directly.
Just by throwing the exception it will be handled by your handler if needed, but also allows us to catch expected errors.
In absence of this feature we'll have to set_error_handler to wrap possible errors to be caught. :(
