### PR TITLE
Not always an Event Error need to throw an Exception.

### DIFF
--- a/src/Whoops/Provider/Zend/ExceptionStrategy.php
+++ b/src/Whoops/Provider/Zend/ExceptionStrategy.php
@@ -43,12 +43,15 @@ class ExceptionStrategy extends BaseExceptionStrategy {
 
             case Application::ERROR_EXCEPTION:
             default:
-                $response = $event->getResponse();
-                if (!$response || $response->getStatusCode() === 200) {
-                    header('HTTP/1.0 500 Internal Server Error', true, 500);
+                $exception = $event->getParam('exception');
+                if($exception) {
+                    $response = $event->getResponse();
+                    if (!$response || $response->getStatusCode() === 200) {
+                        header('HTTP/1.0 500 Internal Server Error', true, 500);
+                    }
+                    ob_clean();
+                    $this->run->handleException($event->getParam('exception'));
                 }
-                ob_clean();
-                $this->run->handleException($event->getParam('exception'));
                 break;
         }
     }


### PR DESCRIPTION
In some cases you need to create an Event Error without generating an Exception:
- Login with a Profile Selection, forcing to use only few routes.
