### PR TITLE
Changed default title

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ $handler->addDataTable('Killer App Details', array(
 ));
 
 // Set the title of the error page:
-$handler->setPageTitle("We're all going to be fired!");
+$handler->setPageTitle("Whoops! There was a problem.");
 
 $run->pushHandler($handler);
 


### PR DESCRIPTION
Whoops is pretty cool. I copied the demo code into a project I'm working on to try it out and it made things way easier. My intention was to only use it in dev environments, but it managed to find its way to production tonight. And the first thing someone saw was:

**"We're all going to be fired!"**

As it turns out, that's a really scary message to someone who doesn't know what's going on! Even though this was entirely my fault, may I suggest using a slightly less scary page title just in case this happens to someone else in the future?
