### PR TITLE
HHVM Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - composer install --no-interaction --prefer-source --dev
 
 script:
-  - phpunit
+  - vendor/bin/phpunit --verbose
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,21 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "mockery/mockery": "dev-master",
-        "silex/silex": "1.0.*@dev"
+        "phpunit/phpunit": "4.0.*",
+        "mockery/mockery": "0.9.*",
+        "silex/silex": "1.0.*"
     },
     "autoload": {
         "psr-0": {
-            "Whoops": "src/"
+            "Whoops": "src/",
+            "Whoops": "tests/"
         }
-    }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.1-dev"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/tests/Whoops/Handler/PrettyPageHandlerTest.php
+++ b/tests/Whoops/Handler/PrettyPageHandlerTest.php
@@ -247,6 +247,10 @@ class PrettyPageHandlerTest extends TestCase
 
     public function testEditorXdebug()
     {
+        if (defined('HHVM_VERSION')) {
+            return $this->markTestSkipped('HHVM does not support xdebug.');
+        }
+
         $originalValue = ini_get('xdebug.file_link_format');
 
         ini_set('xdebug.file_link_format', '%f:%l');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,5 +6,4 @@
  * Bootstraper for PHPUnit tests.
  */
 error_reporting(E_ALL | E_STRICT);
-$loader = require_once __DIR__ . '/../vendor/autoload.php';
-$loader->add('Whoops\\', __DIR__);
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Mockery 0.9 is required for hhvm. As of January this year, the master branch was aliased as 0.9, so we are technically still loading the same version, just in a cleaner way.

PHPUnit 4.0 is required for proper hhvm support. PHPUnit 4.0 will be tagged as stable on 7th March this year.

HHVM doesn't support xdebug, so I have marked that test as skipped. So we can see skipped test warnings, I have added the verbose flag to phpunit when we run it in travis.yml.

I've also added a 1.1 branch alias to the master.
