### PR TITLE
Updated Composer Dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "mockery/mockery": "0.9.*@dev",
-        "silex/silex": "1.0.*@dev"
+        "mockery/mockery": "0.9.*",
+        "silex/silex": "1.1.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Why were we loading the latest dev version of the packages. Surely it would be better to check if whoops works against the current stable version of the packages. I've also bumped silex to 1.1 from 1.0.
