### PR TITLE
Removed Two Unused Use Statements

### DIFF
--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -6,7 +6,6 @@
 
 namespace Whoops\Handler;
 use Whoops\Handler\Handler;
-use Whoops\Exception\Frame;
 use Whoops\Exception\Formatter;
 
 /**

--- a/src/Whoops/Handler/XmlResponseHandler.php
+++ b/src/Whoops/Handler/XmlResponseHandler.php
@@ -7,7 +7,6 @@
 namespace Whoops\Handler;
 
 use SimpleXMLElement;
-use Whoops\Exception\Frame;
 use Whoops\Handler\Handler;
 use Whoops\Exception\Formatter;
 


### PR DESCRIPTION
Whoops\Exception\Frame is unused in Whoops\Handler\JsonResponseHandler and Whoops\Handler\XmlResponseHandler.
