### PR TITLE
exit(1) instead of exit()

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -275,7 +275,7 @@ class Run
         }
 
         if($willQuit) {
-            exit;
+            exit(1);
         }
 
         return $output;


### PR DESCRIPTION
Terminating the script after handling an exception should return error exit status to the caller of the script.
