### PR TITLE
Specify correct delimiter for preg_quote() call.

### DIFF
--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -350,7 +350,7 @@ class RunTest extends TestCase
             })
         ;
 
-        $run->silenceErrorsInPaths('@^'.preg_quote(__FILE__).'$@', E_USER_NOTICE);
+        $run->silenceErrorsInPaths('@^'.preg_quote(__FILE__, '@').'$@', E_USER_NOTICE);
         trigger_error('Test', E_USER_NOTICE);
         $this->assertTrue(true);
     }


### PR DESCRIPTION
The call uses `@` as delimiter so preg_quote() should know that.
