### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "php": ">=5.3.3",
         "mockery/mockery": "0.9.*"
     },
     "autoload": {


### PR DESCRIPTION
We really don't need that there. If anything, it is just going to cause issues. Mockery itself specifies its minimum php version. We don't need to do that too.
