### PR TITLE
Clean up toXml

### DIFF
--- a/src/Whoops/Handler/XmlResponseHandler.php
+++ b/src/Whoops/Handler/XmlResponseHandler.php
@@ -98,18 +98,8 @@ class XmlResponseHandler extends Handler
     {
         assert('is_array($data) || $node instanceof Traversable');
 
-        // turn off compatibility mode as simple xml throws a wobbly if you don't.
-        $compatibilityMode = ini_get('zend.ze1_compatibility_mode');
-        if ($compatibilityMode) {
-            ini_set('zend.ze1_compatibility_mode', 0);
-        }
-
         $node = simplexml_load_string("<?xml version='1.0' encoding='utf-8'?><root />");
-        $xml = self::addDataToNode($node, $data)->asXML();
 
-        if ($compatibilityMode) {
-            ini_set('zend.ze1_compatibility_mode', $compatibilityMode);
-        }
-        return $xml;
+        return self::addDataToNode($node, $data)->asXML();
     }
 }


### PR DESCRIPTION
We don't need these hacky things anymore because whoops requires php 5.3 or higher, and this config setting was removed in php 5.3. I assume this code is left over from php 5.2 compatibility.
