### PR TITLE
Fixing API Doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are not using any of these frameworks, here's a very simple way to instal
     $whoops->register();
     ```
 
-For more options, have a look at the **example files** in `examples/` to get a feel for how things work. Also take a look at the [API Documentation](docs/Framework%20Integration.md#API%20Documentation) and the list of available handers below.
+For more options, have a look at the **example files** in `examples/` to get a feel for how things work. Also take a look at the [API Documentation](docs/API%20Documentation.md) and the list of available handers below.
 
 ### Available Handlers
 


### PR DESCRIPTION
I guess the doc was moved but the link was not updated :)
