### PR TITLE
added ZeroClipboard integration

### DIFF
--- a/src/Whoops/Exception/Formatter.php
+++ b/src/Whoops/Exception/Formatter.php
@@ -5,6 +5,7 @@
  */
 
 namespace Whoops\Exception;
+use Whoops\Util\TemplateHelper;
 
 class Formatter
 {
@@ -45,4 +46,38 @@ class Formatter
 
         return $response;
     }
+    
+    public static function formatExceptionPlain(Inspector $inspector) {
+        $tpl = new TemplateHelper();
+        $name = explode("\\", $inspector->getExceptionName());
+        $message = $inspector->getException()->getMessage();
+        $frames = $inspector->getFrames();
+    
+        $plain = '';
+        foreach($name as $i => $nameSection) {
+            if($i == count($name) - 1) {
+                $plain .= $tpl->escape($nameSection);
+            } else {
+                $plain .= $tpl->escape($nameSection) . '\\';
+            }
+        }
+    
+        $plain .= ' thrown with message "';
+        $plain .= $tpl->escape($message);
+        $plain .= '"'."\n\n";
+    
+        $plain .= "Stacktrace:\n";
+        foreach($frames as $i => $frame) {
+            $plain .= "#". (count($frames) - $i - 1). " ";
+            $plain .= $tpl->escape($frame->getClass() ?: '');
+            $plain .= ($frame->getClass() && $frame->getFunction()) ? ":" : "";
+            $plain .= $tpl->escape($frame->getFunction() ?: '');
+            $plain .= ' in ';
+            $plain .= ($frame->getFile() ?: '<#unknown>');
+            $plain .= ':';
+            $plain .= (int) $frame->getLine(). "\n";
+        }
+        
+        return $plain;
+    }    
 }

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -7,6 +7,7 @@
 namespace Whoops\Handler;
 use Whoops\Handler\Handler;
 use Whoops\Util\TemplateHelper;
+use Whoops\Exception\Formatter;
 use InvalidArgumentException;
 use RuntimeException;
 
@@ -141,13 +142,14 @@ class PrettyPageHandler extends Handler
             "frame_code"  => $this->getResource("views/frame_code.html.php"),
             "env_details" => $this->getResource("views/env_details.html.php"),
 
-            "title"        => $this->getPageTitle(),
-            "name"         => explode("\\", $inspector->getExceptionName()),
-            "message"      => $inspector->getException()->getMessage(),
-            "frames"       => $frames,
-            "has_frames"   => !!count($frames),
-            "handler"      => $this,
-            "handlers"     => $this->getRun()->getHandlers(),
+            "title"          => $this->getPageTitle(),
+            "name"           => explode("\\", $inspector->getExceptionName()),
+            "message"        => $inspector->getException()->getMessage(),
+            "plain_exception" => Formatter::formatExceptionPlain($inspector),
+            "frames"         => $frames,
+            "has_frames"     => !!count($frames),
+            "handler"        => $this,
+            "handlers"       => $this->getRun()->getHandlers(),
 
             "tables"      => array(
                 "Server/Request Data"   => $_SERVER,

--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -318,11 +318,20 @@ pre.prettyprint, code.prettyprint {
       background: rgba(255, 100, 100, .17);
     }
 
-#plain-stacktrace {
+#plain-exception {
 	display: none;
 }
 
 #copy-button {
 	display: none;
 	float: right;
+	cursor: pointer;	
+	border: 0;
+}
+
+.clipboard {
+	width:            29px;
+	height:           28px;
+	background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB0AAAAcCAYAAACdz7SqAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3gUUByMD0ZSoGQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAACAklEQVRIx72Wv0sbYRjHP29y1VoXxR9UskjpXTaHoBUcpGgKkS5OZ1Ec/QeKOIhalEghoOCqQsGhFAWbISKYyaFDS1BKKW0TCYrQSdElXSReh9bkksu9iZdLbnrvvee9z/N83+d9nldo2gvjzd5Hxp4246W6J5tJszsxwvxPIbXzwBQDLgABvM1P6JsAwzCkdopl5vqIuWev2K4QpH/4QjjQci/nPCVny3iaNzMcrVUsC1sChFMpwtTu8dTqx7J9dR3a2BngUb0j7Xr+jtjasBR8f+jpNqqqoqoqmqblxjOJq/8GTfhCK8TWhmmykdhRpEIIhBCWMcD51wQXN3KwY3nvYGYgQPbXOMHJKOlMA77QCvsbugXsOFLZ+5+jGULBtyQuFB4PzlrAVSWSGWaptpdbjAcniaZv6RhcIL6VByvVZqsQouBMdutJkrrVrr1/gdjqN4Ze/3DvyBwcnnF9I7N4gC8YYdqNSHP7uD5G/7pdJRrl/ecIva1t9IRcgpolLk6qQic8eB+6GOkdrDjSf/OiTD91CS4r+jXrMqWkrgvUtuDbeVNTKGzw6SRDto5QBc5Yehlg0WbTc8mwHCeld1u+yZSySySlspTHFmZUeIkrgBYvtvPcyBdXkqWKq5OLmbk/luqVYjPOd3lxLXf/J/P7mJ0oCL/fX1Yfs4RO5CxW8C97dLBw2Q3fUwAAAABJRU5ErkJggg==');
+	background-repeat: no-repeat;
 }

--- a/src/Whoops/Resources/js/whoops.base.js
+++ b/src/Whoops/Resources/js/whoops.base.js
@@ -44,24 +44,16 @@ Zepto(function($) {
   
   if (typeof ZeroClipboard !== "undefined") {
 	  ZeroClipboard.config({
-		  moviePath: '//cdnjs.cloudflare.com/ajax/libs/zeroclipboard/1.3.5/ZeroClipboard.swf',
+		  moviePath: '//ajax.cdnjs.com/ajax/libs/zeroclipboard/1.3.5/ZeroClipboard.swf',
 	  });
 
 	  var clipEl = document.getElementById("copy-button");
 	  var clip = new ZeroClipboard( clipEl );
 	  var $clipEl = $(clipEl);
-	  $clipEl.data('origin-label', $clipEl.text());
 
 	  // show the button, when swf could be loaded successfully from CDN
 	  clip.on("load", function() {
 		  $clipEl.show();
-	  });
-
-	  clip.on( "complete", function( event ) {
-		  $clipEl.text("copied...");
-		  setTimeout(function() {
-			  $clipEl.text($clipEl.data('origin-label'));
-		  }, 3000);
 	  });
   }
 });

--- a/src/Whoops/Resources/views/frame_list.html.php
+++ b/src/Whoops/Resources/views/frame_list.html.php
@@ -1,34 +1,6 @@
 <?php /* List file names & line numbers for all stack frames;
          clicking these links/buttons will display the code view
          for that particular frame */ ?>
-<button id="copy-button" data-clipboard-target="plain-stacktrace" title="click to copy the exception and stacktrace into the clipboard">
-copy into clipboard
-</button>
-<span id="plain-stacktrace"><?php 
-foreach($name as $i => $nameSection):
-  if($i == count($name) - 1):
-    echo $tpl->escape($nameSection);
-  else: 
-    echo $tpl->escape($nameSection) . '\\';
-  endif;
-endforeach;
-
-echo ' thrown with message "';
-echo $tpl->escape($message);
-echo '"'."\n\n";
-
-echo "Stacktrace:\n";
-foreach($frames as $i => $frame):
-    echo "#". (count($frames) - $i - 1). " ";
-    echo $tpl->escape($frame->getClass() ?: '');
-    echo ($frame->getClass() && $frame->getFunction()) ? ":" : "";
-    echo $tpl->escape($frame->getFunction() ?: '');
-    echo ' in '; 
-    echo ($frame->getFile() ?: '<#unknown>');
-    echo ':';
-    echo (int) $frame->getLine(). "\n";
-endforeach; ?></span>
-
 <?php foreach($frames as $i => $frame): ?>
   <div class="frame <?php echo ($i == 0 ? 'active' : '') ?>" id="frame-line-<?php echo $i ?>">
       <div class="frame-method-info">

--- a/src/Whoops/Resources/views/header.html.php
+++ b/src/Whoops/Resources/views/header.html.php
@@ -7,6 +7,8 @@
         <?php echo $tpl->escape($nameSection) . ' \\' ?>
       <?php endif ?>
     <?php endforeach ?>
+    <button id="copy-button" class="clipboard" data-clipboard-target="plain-exception" title="copy exception into clipboard"></button>
+    <span id="plain-exception"><?php echo $plain_exception ?></span>
   </h3>
   <p class="exc-message">
     <?php echo $tpl->escape($message) ?>


### PR DESCRIPTION
this pr adds integration with zero clipboard[1].

clicking the button copies the exception and its backtrace into the clipboard to ease e.g. creation of bugtracking tickets etc.

![clip](https://cloud.githubusercontent.com/assets/120441/3012369/f39c7b60-df38-11e3-9363-43cd8ccf5dfa.png)

clicking the button copies the following plain text into the clipboard:

```
Exception thrown with message "wah"

Stacktrace:
#4 Exception in XXXXX/app/www/controllers/IndexController.php:12
#3 IndexController:index in XXX/lib/ActionController.php:778
#2 ActionController:invokeAction in XXX/lib/ActionController.php:290
#1 ActionController:render in XXXCore.php:65
#0 include_once in XXX/public/www/index.php:29
```

Since this feature requires a external `ZeroClipboard.swf` file, I adjusted the path to load it from the cloudfare CDN. The "Copy to Clipboard" button only appears when the external resource could be loaded properly.

[1] https://github.com/zeroclipboard/zeroclipboard
