### PR TITLE
Include exception code and, if applicable, error constant.

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -6,6 +6,7 @@
 
 namespace Whoops\Handler;
 use Whoops\Handler\Handler;
+use Whoops\Util\Misc;
 use Whoops\Util\TemplateHelper;
 use Whoops\Exception\Formatter;
 use InvalidArgumentException;
@@ -127,6 +128,12 @@ class PrettyPageHandler extends Handler
         $inspector = $this->getInspector();
         $frames    = $inspector->getFrames();
 
+        $code = $inspector->getException()->getCode();
+
+        if ($inspector->getException() instanceof \ErrorException) {
+            $code = Misc::translateErrorCode($code);
+        }
+
         // List of variables that will be passed to the layout template.
         $vars = array(
             "page_title" => $this->getPageTitle(),
@@ -145,6 +152,7 @@ class PrettyPageHandler extends Handler
             "title"          => $this->getPageTitle(),
             "name"           => explode("\\", $inspector->getExceptionName()),
             "message"        => $inspector->getException()->getMessage(),
+            "code"           => $code,
             "plain_exception" => Formatter::formatExceptionPlain($inspector),
             "frames"         => $frames,
             "has_frames"     => !!count($frames),

--- a/src/Whoops/Resources/views/header.html.php
+++ b/src/Whoops/Resources/views/header.html.php
@@ -7,6 +7,9 @@
         <?php echo $tpl->escape($nameSection) . ' \\' ?>
       <?php endif ?>
     <?php endforeach ?>
+    <?php if($code): ?>
+      <span title="Exception Code">(<?php echo $tpl->escape($code) ?>)</span>
+    <?php endif ?>
     <button id="copy-button" class="clipboard" data-clipboard-target="plain-exception" title="copy exception into clipboard"></button>
     <span id="plain-exception"><?php echo $tpl->escape($plain_exception) ?></span>
   </h3>

--- a/src/Whoops/Util/Misc.php
+++ b/src/Whoops/Util/Misc.php
@@ -22,4 +22,21 @@ class Misc
 	{
 		return isset($_SERVER["REQUEST_URI"]) && !headers_sent();
 	}
+
+	/**
+	 * Translate ErrorException code into the represented constant.
+	 *
+	 * @param int $error_code
+	 * @return string
+	 */
+	public static function translateErrorCode($error_code)
+	{
+		$constants = get_defined_constants(true);
+		foreach ($constants['Core'] as $constant => $value) {
+			if (substr($constant, 0, 2) == 'E_' && $value == $error_code) {
+				return $constant;
+			}
+		}
+		return "E_UNKNOWN";
+	}
 }

--- a/tests/Whoops/Util/MiscTest.php
+++ b/tests/Whoops/Util/MiscTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Whoops - php errors for cool kids
+ * @author Filipe Dobreira <http://github.com/filp>
+ */
+
+namespace Whoops\Util;
+use Whoops\TestCase;
+use Whoops\Util\Misc;
+
+class MiscTest extends TestCase
+{
+    /**
+     * @dataProvider provideTranslateException
+     * @param string $expected_output
+     * @param int $exception_code
+     */
+    public function testTranslateException($expected_output, $exception_code)
+    {
+        $output = Misc::translateErrorCode($exception_code);
+        $this->assertEquals($expected_output, $output);
+    }
+
+    public function provideTranslateException()
+    {
+        return array(
+            // When passing an error constant value, ensure the error constant
+            // is returned.
+            array('E_USER_WARNING', E_USER_WARNING),
+
+            // When passing a value not equal to an error constant, ensure
+            // E_UNKNOWN is returned.
+            array('E_UNKNOWN', 3)
+        );
+    }
+}


### PR DESCRIPTION
This resolves Issue #65 by including the exception code or error constant after the exception name in PrettyPageHandler.
![screenshot from 2014-05-22 08 31 35](https://cloud.githubusercontent.com/assets/44527/3054284/f7af423a-e1b5-11e3-8a2a-2465ed2408b1.png)
