### PR TITLE
Fixed soap fault response for strice soap clients

### DIFF
--- a/src/Whoops/Handler/SoapResponseHandler.php
+++ b/src/Whoops/Handler/SoapResponseHandler.php
@@ -39,7 +39,7 @@ class SoapResponseHandler extends Handler
         $xml .= '    <SOAP-ENV:Fault>';
         $xml .= '      <faultcode>'. htmlspecialchars($exception->getCode()) .'</faultcode>';
         $xml .= '      <faultstring>'. htmlspecialchars($exception->getMessage()) .'</faultstring>';
-        $xml .= '      <detail>'. htmlspecialchars($exception->getTraceAsString()) .'</detail>';
+        $xml .= '      <detail><trace>'. htmlspecialchars($exception->getTraceAsString()) .'</trace></detail>';
         $xml .= '    </SOAP-ENV:Fault>';
         $xml .= '  </SOAP-ENV:Body>';
         $xml .= '</SOAP-ENV:Envelope>';


### PR DESCRIPTION
Soap clients which validate the soap fault against a xsd require the stacktrace to be nested in a child-element of `<detail>`
