### PR TITLE
Use PlainTextHandler when in CLI mode

### DIFF
--- a/src/Whoops/Provider/Silex/WhoopsServiceProvider.php
+++ b/src/Whoops/Provider/Silex/WhoopsServiceProvider.php
@@ -24,7 +24,7 @@ class WhoopsServiceProvider implements ServiceProviderInterface
     {
         // There's only ever going to be one error page...right?
         $app['whoops.error_page_handler'] = $app->share(function() {
-            if(php_sapi_name() === 'cli') {
+            if(PHP_SAPI === 'cli') {
                 return new PlainTextHandler;
             } else {
                 return new PrettyPageHandler;


### PR DESCRIPTION
When runnign a Silex app in CLI mode, errors are lost because of the PrettyPageHandler, use PlainTextHandler in CLI mode to fix this.
Maybe $app['whoops.error_page_handler'] should only be defined if it's not already defined? That way the application can determine which handler to use, if it wants to.
