### PR TITLE
Added array_key_exists() check for get_defined_constants()

### DIFF
--- a/src/Whoops/Util/Misc.php
+++ b/src/Whoops/Util/Misc.php
@@ -32,9 +32,11 @@ class Misc
 	public static function translateErrorCode($error_code)
 	{
 		$constants = get_defined_constants(true);
-		foreach ($constants['Core'] as $constant => $value) {
-			if (substr($constant, 0, 2) == 'E_' && $value == $error_code) {
-				return $constant;
+		if (array_key_exists('Core' , $constants)) {
+			foreach ($constants['Core'] as $constant => $value) {
+				if (substr($constant, 0, 2) == 'E_' && $value == $error_code) {
+					return $constant;
+				}
 			}
 		}
 		return "E_UNKNOWN";


### PR DESCRIPTION
Added array_key_exists check to check for misconfigured environments. This happend to me on Google App Engine.

I've reported the problem to Google but to add some resilience to the library I've added a check.

https://code.google.com/p/googleappengine/issues/detail?id=11236
