### PR TITLE
Not catching fatal erros on hhvm 3.3

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -377,16 +377,12 @@ class Run
 
     private static function isLevelFatal($level)
     {
-        return in_array(
-            $level,
-            array(
-                E_ERROR,
-                E_PARSE,
-                E_CORE_ERROR,
-                E_CORE_WARNING,
-                E_COMPILE_ERROR,
-                E_COMPILE_WARNING
-            )
-        );
+        $errors = E_ERROR
+                | E_PARSE
+                | E_CORE_ERROR
+                | E_CORE_WARNING
+                | E_COMPILE_ERROR
+                | E_COMPILE_WARNING;
+        return $level & $errors;
     }
 }


### PR DESCRIPTION
On hhvm 3.3 there is a special error code for some fatal errors. https://github.com/facebook/hhvm/blob/master/hphp/runtime/base/runtime-error.h

Instead of checking for fatal errors to be in a specific array there should be a bitwise AND.
