### PR TITLE
Added a reference to whoops-stackphp

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ If you use Laravel 4, you already have Whoops. There are also community-provided
 [Yii 1](https://github.com/igorsantos07/yii-whoops),
 [FuelPHP](https://github.com/indigophp/fuel-whoops),
 [Slim](https://github.com/zeuxisoo/php-slim-whoops/),
-[Pimple](https://github.com/texthtml/whoops-pimple).
+[Pimple](https://github.com/texthtml/whoops-pimple),
+or any framework consuming [StackPHP middlewares](https://github.com/thecodingmachine/whoops-stackphp).
 
 If you are not using any of these frameworks, here's a very simple way to install:
 


### PR DESCRIPTION
Hi!

I just built a very simple bridge between [StackPHP](http://stackphp.com/) and Whoops (https://github.com/thecodingmachine/whoops-stackphp). If you are not aware, StackPHP is a development convention based on Symfony 2 HttpKernelInterface to build "middlewares" routers that can be chained easily.
The Whoops middleware is heavily based on the code of the Silex integration, and is now used by default in the Mouf PHP framework (http://mouf-php.com)
Hope you'll enjoy it.
