### PR TITLE
directly invoke callables instead of call_user_func.

### DIFF
--- a/src/Whoops/Handler/CallbackHandler.php
+++ b/src/Whoops/Handler/CallbackHandler.php
@@ -43,7 +43,10 @@ class CallbackHandler extends Handler
         $exception = $this->getException();
         $inspector = $this->getInspector();
         $run       = $this->getRun();
+        $callable  = $this->callable;
 
-        return call_user_func($this->callable, $exception, $inspector, $run);
+        // invoke the callable directly, to get simpler stacktraces (in comparison to call_user_func).
+        // this assumes that $callable is a properly typed php-callable, which we check in __construct().
+        return $callable($exception, $inspector, $run);
     }
 }

--- a/tests/Whoops/Handler/CallbackHandlerTest.php
+++ b/tests/Whoops/Handler/CallbackHandlerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Whoops\Handler;
+
+use Whoops\TestCase;
+use Whoops\Handler\CallbackHandler;
+
+class CallbackHandlerTest extends TestCase
+{
+    public function testSimplifiedBacktrace() {
+        $handler = new CallbackHandler(function($exception, $inspector, $run) {
+            return debug_backtrace();
+        });
+        $backtrace = $handler->handle();
+        
+        foreach($backtrace as $frame) {
+            $this->assertNotContains('call_user_func', $frame['function']);
+        }
+    }
+}


### PR DESCRIPTION
eases debugging, because of simpler stacktraces.

This is the only place where we have a strongly typed `callable` therefore this optimization cannot be made anywhere else.