### PR TITLE
register the handleError() only for E_* levels defined in error_reportin...

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -114,7 +114,7 @@ class Run
             class_exists("\\Whoops\\Exception\\Frame");
             class_exists("\\Whoops\\Exception\\Inspector");
 
-            set_error_handler(array($this, self::ERROR_HANDLER));
+            set_error_handler(array($this, self::ERROR_HANDLER), error_reporting());
             set_exception_handler(array($this, self::EXCEPTION_HANDLER));
             register_shutdown_function(array($this, self::SHUTDOWN_HANDLER));
 


### PR DESCRIPTION
...g()

This improves performance, because handleError() is not invoked for every E_* level, but only those we are interessted in. This removed a lot of unnecessary invocations which lead to a no-op as the error-level will be filtered nevertheless.