### PR TITLE
Fix #262: Silenced errors won't fill error_get_last() array

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -302,7 +302,8 @@ class Run
      * @param string $file
      * @param int    $line
      *
-     * @return bool|null
+     * @return bool
+     * @throws ErrorException
      */
     public function handleError($level, $message, $file = null, $line = null)
     {
@@ -322,7 +323,13 @@ class Run
             } else {
                 $this->handleException($exception);
             }
+            // Do not propagate errors which were already handled by Whoops.
+            return true;
         }
+
+        // Propagate error to the next handler, allows error_get_last() to
+        // work on silenced errors.
+        return false;
     }
 
     /**

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -347,6 +347,24 @@ class RunTest extends TestCase
     }
 
     /**
+     * @covers Whoops\Run::handleError
+     */
+    public function testGetSilencedError()
+    {
+        $run = $this->getRunInstance();
+        $run->register();
+
+        $handler = $this->getHandler();
+        $run->pushHandler($handler);
+
+        @strpos();
+
+        $error = error_get_last();
+
+        $this->assertTrue($error && strpos($error['message'], 'strpos()') !== false);
+    }
+
+    /**
      * @covers Whoops\Run::handleException
      * @covers Whoops\Run::writeToOutput
      */


### PR DESCRIPTION
Pass silenced and ignored errors to default error handler.