### PR TITLE
fixed ellipsis for non-utf8 apps

### DIFF
--- a/src/Whoops/Exception/Frame.php
+++ b/src/Whoops/Exception/Frame.php
@@ -58,7 +58,7 @@ class Frame implements Serializable
         if ($shortened && is_string($file)) {
             // Replace the part of the path that all frames have in common, and add 'soft hyphens' for smoother line-breaks.
             $dirname = dirname(dirname(dirname(dirname(dirname(dirname(__DIR__))))));
-            $file = str_replace($dirname, "…", $file);
+            $file = str_replace($dirname, "&hellip;", $file);
             $file = str_replace("/", "/&shy;", $file);
         }
 


### PR DESCRIPTION
When using Whoops in a non-utf8 app, the utf8 ellipsis char in Frame.php cannot be rendered.

With this PR we use the html-entity for this character instead which works in all encodings.

In a CP1252 App without this patch the stackframe view looks like http://imgur.com/FQOn54a