### PR TITLE
HHVM fix - flush before exit

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -285,6 +285,7 @@ class Run
         }
 
         if ($willQuit) {
+            flush(); // HHVM fix for https://github.com/facebook/hhvm/issues/4055
             exit(1);
         }
 


### PR DESCRIPTION
Whoops doesn't work for me with HHVM 3.6 due to a minor incompatibility between PHP and HHVM.

See facebook/hhvm#4055. The solution is to add flush() before exit(). IMO this workaround can be removed as soon as HHVM fixes this bug upstream in all their LTS releases.