### PR TITLE
Fixed help overlay flicker

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -348,6 +348,7 @@ pre.prettyprint, code.prettyprint {
 }
 
 #help-overlay {
+	pointer-events: none;
 	display: none;
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
When hovering over the help button, if you move your mouse pointer slowly, the overlay flickers because the button loses 'focus' when the overlay is displayed.

The added CSS property will prevent the overlay from receiving pointer events. It isn't a perfect solution though. It works in all modern browsers, but no versions of IE less than IE11.

http://caniuse.com/#feat=pointer-events