### PR TITLE
Display help button above help overlay

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -341,6 +341,8 @@ pre.prettyprint, code.prettyprint {
 	height:   28px;
 	float: right;
 	margin-left: 10px;
+	position: relative;
+	z-index: 1;
 }
 
 .help button:hover + #help-overlay {


### PR DESCRIPTION
This helps with flickering when the cursor moves over the help button in Chrome (possibly other browsers).