### PR TITLE
getEditorHref returns false if editor is not set

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -324,6 +324,10 @@ class PrettyPageHandler extends Handler
     {
         $editor = $this->getEditor($filePath, $line);
 
+        if (!$editor) {
+            return false;
+        }
+
         // Check that the editor is a string, and replace the
         // %line and %file placeholders:
         if (!isset($editor['url']) || !is_string($editor['url'])) {

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -318,7 +318,7 @@ class PrettyPageHandler extends Handler
      * @throws InvalidArgumentException If editor resolver does not return a string
      * @param  string                   $filePath
      * @param  int                      $line
-     * @return string
+     * @return string|bool
      */
     public function getEditorHref($filePath, $line)
     {


### PR DESCRIPTION
When editor is not set, getEditor returns false and getEditorHref throws the UnexpectedValueException exception.