### PR TITLE
Cleanup .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-vendor/*
-report/*
-phpunit.xml
 composer.lock
-/.idea/
+phpunit.xml
+report
+vendor


### PR DESCRIPTION
Alphabetically sorted and removed `.idea` because that belongs in people's system `.gitignore` file.