### PR TITLE
Adjusted rendering of empty superglobals to take less visual space

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -261,9 +261,12 @@ header {
     hyphens: auto;
   }
 
-  .data-table .empty {
+  .data-table span.empty {
     color: rgba(0, 0, 0, .3);
     font-style: italic;
+  }
+  .data-table label.empty {
+	display: inline;
   }
 
 .handler {

--- a/src/Whoops/Resources/views/env_details.html.php
+++ b/src/Whoops/Resources/views/env_details.html.php
@@ -3,8 +3,8 @@
   <div class="data-table-container" id="data-tables">
     <?php foreach ($tables as $label => $data): ?>
       <div class="data-table" id="sg-<?php echo $tpl->escape($tpl->slug($label)) ?>">
-        <label><?php echo $tpl->escape($label) ?></label>
         <?php if (!empty($data)): ?>
+            <label><?php echo $tpl->escape($label) ?></label>
             <table class="data-table">
               <thead>
                 <tr>
@@ -20,7 +20,8 @@
             <?php endforeach ?>
             </table>
         <?php else: ?>
-          <span class="empty">empty</span>
+            <label class="empty"><?php echo $tpl->escape($label) ?></label>
+            <span class="empty">empty</span>
         <?php endif ?>
       </div>
     <?php endforeach ?>


### PR DESCRIPTION
Before the actual usefull information did not fit onto screen because
the empty-indication of super-globals took too much visual space.

Before http://i.imgur.com/V6iMkD5.png
After http://i.imgur.com/nY18lXi.png