### PR TITLE
Added JSON_PARTIAL_OUTPUT_ON_ERROR to json_encode to handle recursive stack traces

### DIFF
--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -84,7 +84,8 @@ class JsonResponseHandler extends Handler
             header('Content-Type: application/json');
         }
 
-        echo json_encode($response);
+        echo json_encode($response, defined('JSON_PARTIAL_OUTPUT_ON_ERROR') ? JSON_PARTIAL_OUTPUT_ON_ERROR : 0);
+
         return Handler::QUIT;
     }
 }


### PR DESCRIPTION
If the stack trace contains recursion, the JSON output is null by default. The JSON_PARTIAL_OUTPUT_ON_ERROR flag sets the recursive node to null thus allowing the trace to be rendered.

note that JSON_PARTIAL_OUTPUT_ON_ERROR is only available on PHP 5.4+, so support is added for that