### PR TITLE
table cell renderer

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -77,6 +77,12 @@ class PrettyPageHandler extends Handler
     );
 
     /**
+     * Renders HTML for table cell
+     * @var callable
+     */
+    private $cellRenderer;
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -182,6 +188,18 @@ class PrettyPageHandler extends Handler
             return $table instanceof \Closure ? $table() : $table;
         }, $this->getDataTables());
         $vars["tables"] = array_merge($extraTables, $vars["tables"]);
+
+        $cellRenderer = (is_callable($this->cellRenderer)) ?
+            $this->cellRenderer :
+            function ($value) use ($helper) {
+                return $helper->escape(print_r($value, true));
+            };
+
+        foreach ($vars['tables'] as $table => $data) {
+            foreach ($data as $key => $value) {
+                $vars['tables'][$table][$key] = $cellRenderer($value);
+            }
+        }
 
         $helper->setVariables($vars);
         $helper->render($templateFile);
@@ -424,6 +442,16 @@ class PrettyPageHandler extends Handler
     public function getPageTitle()
     {
         return $this->pageTitle;
+    }
+
+    /**
+     * Sets cell renderer - a callback which renders HTML for table cell
+     *
+     * @param callable $callable
+     */
+    public function setCellRenderer($callable)
+    {
+        $this->cellRenderer = $callable;
     }
 
     /**

--- a/src/Whoops/Resources/views/env_details.html.php
+++ b/src/Whoops/Resources/views/env_details.html.php
@@ -15,7 +15,7 @@
             <?php foreach ($data as $k => $value): ?>
               <tr>
                 <td><?php echo $tpl->escape($k) ?></td>
-                <td><?php echo $tpl->escape(print_r($value, true)) ?></td>
+                <td><?php echo $value ?></td>
               </tr>
             <?php endforeach ?>
             </table>


### PR DESCRIPTION
this PR allows user to set custom table cell renderer - i can for example use symfony/var-dumper:

```php
$handler->setCellRenderer(function ($value) {
    ob_start();
    dump($value);
    return ob_get_clean();
});
```