### PR TITLE
remove onlyForAjaxRequests in JsonResponseHandler and move its logic into a re-usable Whoops\isAjaxRequest helper function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         },
         "classmap": [
             "src/deprecated"
+        ],
+        "files": [
+            "src/Whoops/functions.php"
         ]
     },
     "extra": {

--- a/docs/API Documentation.md
+++ b/docs/API Documentation.md
@@ -12,6 +12,10 @@
 - [`Whoops\Handler\JsonResponseHandler`](#handler-json) - Formats errors and exceptions as a JSON payload
 - [`Whoops\Handler\PrettyPageHandler`](#handler-pretty) - Outputs a detailed, fancy error page
 
+### Core Functions:
+- [`Whoops\isAjaxRequest()`](#fn-ajax) - Determines whether the current request was triggered by XMLHttpRequest
+
+
 # Core Classes:
 
 ## <a name="whoops-run"></a> `Whoops\Run`
@@ -239,6 +243,7 @@ Frame::getComments(string $filter = null)
  #=> array
 ```
 
+
 # Core Handlers
 
 ## <a name="handler-callback"></a> `Whoops\Handler\CallbackHandler`
@@ -305,11 +310,6 @@ The `JSON` body has the following format:
 // Should detailed stack trace output also be added to the
 // JSON payload body?
 JsonResponseHandler::addTraceToOutput(bool $yes = null)
- #=> bool
-
-// Should output only be sent if the current request is an
-// AJAX request?
-JsonResponseHandler::onlyForAjaxRequests(bool $yes = null)
  #=> bool
 
 JsonResponseHandler::handle()
@@ -401,4 +401,17 @@ PrettyPageHandler::addEditor(string $editor, $resolver)
 
 PrettyPageHandler::handle()
  #=> int | null
+```
+
+
+# Core Functions:
+
+## <a name="fn-ajax"></a> `Whoops\isAjaxRequest()`
+ #=> boolean
+ 
+```php
+// Use a certain handler only in AJAX triggered requests
+if (Whoops\isAjaxRequest()){
+  $run->addHandler($myHandler)
+}
 ```

--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -21,11 +21,6 @@ class JsonResponseHandler extends Handler
     private $returnFrames = false;
 
     /**
-     * @var bool
-     */
-    private $onlyForAjaxRequests = false;
-
-    /**
      * @param  bool|null  $returnFrames
      * @return bool|$this
      */
@@ -40,39 +35,10 @@ class JsonResponseHandler extends Handler
     }
 
     /**
-     * @param  bool|null $onlyForAjaxRequests
-     * @return null|bool
-     */
-    public function onlyForAjaxRequests($onlyForAjaxRequests = null)
-    {
-        if (func_num_args() == 0) {
-            return $this->onlyForAjaxRequests;
-        }
-
-        $this->onlyForAjaxRequests = (bool) $onlyForAjaxRequests;
-    }
-
-    /**
-     * Check, if possible, that this execution was triggered by an AJAX request.
-     *
-     * @return bool
-     */
-    private function isAjaxRequest()
-    {
-        return (
-            !empty($_SERVER['HTTP_X_REQUESTED_WITH'])
-            && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
-    }
-
-    /**
      * @return int
      */
     public function handle()
     {
-        if ($this->onlyForAjaxRequests() && !$this->isAjaxRequest()) {
-            return Handler::DONE;
-        }
-
         $response = array(
             'error' => Formatter::formatExceptionAsDataArray(
                 $this->getInspector(),

--- a/src/Whoops/functions.php
+++ b/src/Whoops/functions.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: staabm
+ * Date: 21.11.2015
+ * Time: 16:08
+ */
+
+namespace Whoops;
+
+function isAjaxRequest()
+{
+    return (
+        !empty($_SERVER['HTTP_X_REQUESTED_WITH'])
+        && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
+}


### PR DESCRIPTION
closes #319.

As requested I only implemented it in PlainTextHander. Not sure whether we should add it in all handlers.

As it does not make sense in non-http handlers, I would suggest to move the Logic into a `trait` ... thoughts on that?