### PR TITLE
Only support maintained versions of PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: php
 
 php:
-  # 5.3.0 is not supported by Travis
-  - 5.3.3
-  - 5.3
-  - 5.4
+  - 5.5.9
   - 5.5
   - 5.6
   - 7.0
@@ -12,10 +9,7 @@ php:
 
 sudo: false
 
-before_script:
-  - composer self-update
-  # --prefer-source is required to avoid hitting GitHub API limit:
-  # https://github.com/composer/composer/issues/1314
+install:
   - composer install --no-interaction --prefer-source
   - if [ $TRAVIS_PHP_VERSION = "5.6" ]; then PHPUNIT_FLAGS="--coverage-clover build/logs/clover.xml"; fi
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.5.9"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"


### PR DESCRIPTION
What do you make of this? This matches what Laravel and Symfony has done. PHPUnit has gone one step further, and actually only supports PHP 5.6+ now.