### PR TITLE
Fix a typo in an exception message

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -52,7 +52,7 @@ class Run
 
         if (!$handler instanceof HandlerInterface) {
             throw new InvalidArgumentException(
-                  "Argument to " . __METHOD__ . " must be a callable, or instance of"
+                  "Argument to " . __METHOD__ . " must be a callable, or instance of "
                 . "Whoops\\Handler\\HandlerInterface"
             );
         }


### PR DESCRIPTION
You were missing a space between two words, here.