### PR TITLE
Let onlyForAjaxRequests be called on any handler

### DIFF
--- a/docs/API Documentation.md
+++ b/docs/API Documentation.md
@@ -117,6 +117,11 @@ HandlerInterface::setInspector(Whoops\Exception\Inspector $inspector)
 // Sets the Exception for this handler to handle
 HandlerInterface::setException(Exception $exception)
  #=> null
+ 
+// Should output only be sent if the current request is an
+// AJAX request?
+HandlerInterface::onlyForAjaxRequests(bool $yes = null)
+ #=> bool
 ```
 
 ## <a name="inspector"></a> `Whoops\Exception\Inspector`
@@ -305,11 +310,6 @@ The `JSON` body has the following format:
 // Should detailed stack trace output also be added to the
 // JSON payload body?
 JsonResponseHandler::addTraceToOutput(bool $yes = null)
- #=> bool
-
-// Should output only be sent if the current request is an
-// AJAX request?
-JsonResponseHandler::onlyForAjaxRequests(bool $yes = null)
  #=> bool
 
 JsonResponseHandler::handle()

--- a/src/Whoops/Handler/Handler.php
+++ b/src/Whoops/Handler/Handler.php
@@ -38,6 +38,11 @@ abstract class Handler implements HandlerInterface
      * @var Exception $exception
      */
     private $exception;
+    
+    /**
+     * @var bool
+     */
+    private $onlyForAjaxRequests = false;
 
     /**
      * @param Run $run
@@ -53,6 +58,19 @@ abstract class Handler implements HandlerInterface
     protected function getRun()
     {
         return $this->run;
+    }
+    
+    /**
+     * @param  bool|null $onlyForAjaxRequests
+     * @return null|bool
+     */
+    public function onlyForAjaxRequests($onlyForAjaxRequests = null)
+    {
+        if (func_num_args() == 0) {
+            return $this->onlyForAjaxRequests;
+        }
+
+        $this->onlyForAjaxRequests = (bool) $onlyForAjaxRequests;
     }
 
     /**

--- a/src/Whoops/Handler/HandlerInterface.php
+++ b/src/Whoops/Handler/HandlerInterface.php
@@ -34,4 +34,10 @@ interface HandlerInterface
      * @return void
      */
     public function setInspector(Inspector $inspector);
+    
+    /**
+     * @param bool|null $onlyForAjaxRequests
+     * Get or set whether this handler should only be used for Ajax requests.
+     */
+    public function onlyForAjaxRequests($onlyForAjaxRequests = null);
 }

--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -21,11 +21,6 @@ class JsonResponseHandler extends Handler
     private $returnFrames = false;
 
     /**
-     * @var bool
-     */
-    private $onlyForAjaxRequests = false;
-
-    /**
      * @param  bool|null  $returnFrames
      * @return bool|$this
      */
@@ -40,39 +35,10 @@ class JsonResponseHandler extends Handler
     }
 
     /**
-     * @param  bool|null $onlyForAjaxRequests
-     * @return null|bool
-     */
-    public function onlyForAjaxRequests($onlyForAjaxRequests = null)
-    {
-        if (func_num_args() == 0) {
-            return $this->onlyForAjaxRequests;
-        }
-
-        $this->onlyForAjaxRequests = (bool) $onlyForAjaxRequests;
-    }
-
-    /**
-     * Check, if possible, that this execution was triggered by an AJAX request.
-     *
-     * @return bool
-     */
-    private function isAjaxRequest()
-    {
-        return (
-            !empty($_SERVER['HTTP_X_REQUESTED_WITH'])
-            && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
-    }
-
-    /**
      * @return int
      */
     public function handle()
     {
-        if ($this->onlyForAjaxRequests() && !$this->isAjaxRequest()) {
-            return Handler::DONE;
-        }
-
         $response = array(
             'error' => Formatter::formatExceptionAsDataArray(
                 $this->getInspector(),

--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -176,6 +176,23 @@ class PlainTextHandler extends Handler
         }
         $this->outputOnlyIfCommandLine = (bool) $outputOnlyIfCommandLine;
     }
+    
+    public function onlyForAjaxRequests($onlyForAjaxRequests = null) {
+        if ($onlyForAjaxRequests) {
+            // A little magic to save the user some head-scratching.
+            // $outputOnlyIfCommandLine is true by default, but that's plainly
+            // wrong when the user is setting onlyForAjaxRequests to true, so
+            // we quietly set $outputOnlyIfCommandLine to false.
+            $this->outputOnlyIfCommandLine(false);
+        }
+        
+        // Call super. It needs to be this ugly because the parent method's
+        // behaviour depends on the number of arguments passed.
+        return call_user_func_array(
+            array('parent', 'onlyForAjaxRequests'),
+            func_get_args()
+        );
+    }
 
     /**
      * Only output to logger.

--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -246,6 +246,10 @@ class Run
         $handlerResponse = null;
 
         foreach (array_reverse($this->handlerStack) as $handler) {
+            if ($handler->onlyForAjaxRequests() && !$this->isAjaxRequest()) {
+                continue;
+            }
+            
             $handler->setRun($this);
             $handler->setInspector($inspector);
             $handler->setException($exception);
@@ -394,5 +398,17 @@ class Run
         echo $output;
 
         return $this;
+    }
+    
+    /**
+     * Check, if possible, that this execution was triggered by an AJAX request.
+     *
+     * @return bool
+     */
+    private function isAjaxRequest()
+    {
+        return (
+            !empty($_SERVER['HTTP_X_REQUESTED_WITH'])
+            && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
     }
 }

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -43,6 +43,10 @@ class RunTest extends TestCase
 
             ->shouldReceive('setException')
                 ->andReturn(null)
+            ->mock()
+            
+            ->shouldReceive('onlyForAjaxRequests')
+                ->andReturn(false)
             ->mock();
     }
 


### PR DESCRIPTION
Perhaps this is a more useful approach than https://github.com/filp/whoops/pull/321 ?

This pull request has two commits; it's possible you'll want to merge the first and reject the second.

The first commit moves `onlyForAjaxRequests()` to the base `Handler()` class and has `Run()` call it on all Handlers. The advantage of this over https://github.com/filp/whoops/pull/321 is that it doesn't break backwards compatibility for people who are already calling `onlyForAjaxRequests()` and it keeps all Handler configuration done by calling Handler methods instead of needing to pull some conditional logic out of the handler. Disadvantages I can see are that it breaks backwards compatibility for anyone who was implementing `HandlerInterface` themself without inheriting from `Handler` (which is probably a bad idea in the first place) and perhaps makes it less obvious how to add only-for-Ajax behaviour to a closure (since that will require explicitly creating a `CallbackHandler` rather than relying on the automatic creation caused by passing a closure to `pushHandler()`.

The second commit adds a teeny hack to `PlainTextHandler` to make it play nicer with the use case I described in https://github.com/filp/whoops/issues/319. Basically, `PlainTextHandler` only outputs to the command line by default, but if we're calling `onlyForAjaxRequests(true)` on it then plainly that's not the behaviour we want, so I made the `onlyForAjaxRequests(true)` call automatically turn off the command-line-only switch. The upside of this is that it removes a confusing trap that people will stumble into when using the PlainTextHandler for Ajax calls. (At least, I was confused when testing!) The downside is that if somebody has got their PlainTextHandler working with Ajax calls by unknowingly relying on this magic behaviour and then they decide to make the PlainTextHandler their sole handler for using everything by deleting their other handlers and removing the `->onlyForAjaxRequests(true)` line from their code, then suddenly their handler won't work on the web at all, and they'll have an *even more confusing* debugging task.

I don't see an easy way to dodge these tradeoffs and I think the calls I've made in both commits are probably the best ones on balance, but it's your call on both.

I don't have enough PHPUnit or Mockery knowledge to feel confident adding tests so I just did the minimum test-modification necessary to keep the current tests passing. I also manually tested that `->onlyForAjaxRequests()` works properly on the PlainTextHandler now.