### PR TITLE
[WIP] Refactor method onlyForAjaxRequests in JsonResponseHandler

### DIFF
--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -40,15 +40,22 @@ class JsonResponseHandler extends Handler
     }
 
     /**
-     * @param  bool|null $onlyForAjaxRequests
+     * Get if handler is only for ajax requests.
+     *
      * @return null|bool
      */
-    public function onlyForAjaxRequests($onlyForAjaxRequests = null)
+    public function onlyForAjaxRequests()
     {
-        if (func_num_args() == 0) {
-            return $this->onlyForAjaxRequests;
-        }
+        return $this->onlyForAjaxRequests;
+    }
 
+    /**
+     * Set if handler is only for ajax requests.
+     *
+     * @param bool $onlyForAjaxRequests
+     */
+    public function setOnlyForAjaxRequests($onlyForAjaxRequests = false)
+    {
         $this->onlyForAjaxRequests = (bool) $onlyForAjaxRequests;
     }
 


### PR DESCRIPTION
This method has two jobs, and this PR will split that into one and add a new method to set the flag for onlyForAjaxRequest with `setOnlyForAjaxRequest`. It is a good practice to have one method do one thing, not multiple. :smile: 

I spotted this in PR #332 when looking at the changes there.

If PR #332 is accepted I would need to update my PR.

Cheers