### PR TITLE
Added support for printing frame args in the framestack.

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -133,6 +133,15 @@ header {
       font-size: 14px;
     }
 
+    .frame-arg {
+      margin-left: 20px;
+      display: block;
+    }
+
+    .frame-arg-separated .sf-dump::after {
+      content: ',';
+    }
+
     .frame-index {
       font-size: 11px;
       color: #a29d9d;

--- a/src/Whoops/Resources/views/env_details.html.php
+++ b/src/Whoops/Resources/views/env_details.html.php
@@ -17,7 +17,7 @@
             <?php foreach ($data as $k => $value): ?>
               <tr>
                 <td><?php echo $tpl->escape($k) ?></td>
-                <td><?php echo $tpl->escape($tpl->dump($value)) ?></td>
+                <td><?php echo $tpl->dump($value) ?></td>
               </tr>
             <?php endforeach ?>
             </table>

--- a/src/Whoops/Resources/views/frame_list.html.php
+++ b/src/Whoops/Resources/views/frame_list.html.php
@@ -7,6 +7,7 @@
         <span class="frame-index"><?php echo (count($frames) - $i - 1) ?></span>
         <span class="frame-class"><?php echo $tpl->escape($frame->getClass() ?: '') ?></span>
         <span class="frame-function"><?php echo $tpl->escape($frame->getFunction() ?: '') ?></span>
+        <?php echo $tpl->dumpArgs($frame); ?>
       </div>
 
     <span class="frame-file">
@@ -14,4 +15,4 @@
    --><span class="frame-line"><?php echo (int) $frame->getLine() ?></span>
     </span>
   </div>
-<?php endforeach ?>
+<?php endforeach; ?>


### PR DESCRIPTION
This adds printing of frame args, in case symfony/var-dumper is present.
When the sf component is missing the page looks as before. I took this path, because our default `print_r` var-dumping produces a big mess in this small panel on the left.

Looks like
http://i.imgur.com/PzebmFI.png
http://i.imgur.com/Ortpdmi.png

Should fix #15.

In case https://github.com/symfony/symfony/issues/16741 gets fixed, we might also get away from the default-expanded objects.