### PR TITLE
Removed PlainTextHandler->(onlyForCommandLine|outputOnlyIfCommandLine…

### DIFF
--- a/docs/API Documentation.md
+++ b/docs/API Documentation.md
@@ -14,6 +14,7 @@
 
 ### Core Functions:
 - [`Whoops\isAjaxRequest()`](#fn-ajax) - Determines whether the current request was triggered by XMLHttpRequest
+- [`Whoops\isCommandLine()`](#fn-cli) - Determines whether the current request was triggered via php commandline interface (CLI)
 
 
 # Core Classes:
@@ -408,10 +409,33 @@ PrettyPageHandler::handle()
 
 ## <a name="fn-ajax"></a> `Whoops\isAjaxRequest()`
  #=> boolean
- 
+
 ```php
 // Use a certain handler only in AJAX triggered requests
 if (Whoops\isAjaxRequest()){
   $run->addHandler($myHandler)
 }
+```
+
+## <a name="fn-cli"></a> `Whoops\isCommandLine()`
+ #=> boolean
+
+```php
+// Use a certain handler only in php cli
+if (Whoops\isCommandLine()){
+  $run->addHandler($myHandler)
+}
+```
+
+```php
+/*
+Output the error message only if using command line.
+else, output to logger if available.
+Allow to safely add this handler to web pages.
+*/
+$plainTextHandler = new PlainTextHandler();
+if (!Whoops\isCommandLine()){
+  $plainTextHandler->loggerOnly(true);
+}
+$run->addHandler($myHandler)
 ```

--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -44,16 +44,6 @@ class PlainTextHandler extends Handler
     /**
      * @var bool
      */
-    private $onlyForCommandLine = false;
-
-    /**
-     * @var bool
-     */
-    private $outputOnlyIfCommandLine = true;
-
-    /**
-     * @var bool
-     */
     private $loggerOnly = false;
 
     /**
@@ -150,34 +140,6 @@ class PlainTextHandler extends Handler
     }
 
     /**
-     * Restrict error handling to command line calls.
-     * @param  bool|null $onlyForCommandLine
-     * @return null|bool
-     */
-    public function onlyForCommandLine($onlyForCommandLine = null)
-    {
-        if (func_num_args() == 0) {
-            return $this->onlyForCommandLine;
-        }
-        $this->onlyForCommandLine = (bool) $onlyForCommandLine;
-    }
-
-    /**
-     * Output the error message only if using command line.
-     * else, output to logger if available.
-     * Allow to safely add this handler to web pages.
-     * @param  bool|null $outputOnlyIfCommandLine
-     * @return null|bool
-     */
-    public function outputOnlyIfCommandLine($outputOnlyIfCommandLine = null)
-    {
-        if (func_num_args() == 0) {
-            return $this->outputOnlyIfCommandLine;
-        }
-        $this->outputOnlyIfCommandLine = (bool) $outputOnlyIfCommandLine;
-    }
-
-    /**
      * Only output to logger.
      * @param  bool|null $loggerOnly
      * @return null|bool
@@ -192,31 +154,12 @@ class PlainTextHandler extends Handler
     }
 
     /**
-     * Check, if possible, that this execution was triggered by a command line.
-     * @return bool
-     */
-    private function isCommandLine()
-    {
-        return PHP_SAPI == 'cli';
-    }
-
-    /**
-     * Test if handler can process the exception..
-     * @return bool
-     */
-    private function canProcess()
-    {
-        return $this->isCommandLine() || !$this->onlyForCommandLine();
-    }
-
-    /**
      * Test if handler can output to stdout.
      * @return bool
      */
     private function canOutput()
     {
-        return ($this->isCommandLine() || ! $this->outputOnlyIfCommandLine())
-            && ! $this->loggerOnly();
+        return !$this->loggerOnly();
     }
 
     /**
@@ -297,10 +240,6 @@ class PlainTextHandler extends Handler
      */
     public function handle()
     {
-        if (! $this->canProcess()) {
-            return Handler::DONE;
-        }
-
         $exception = $this->getException();
 
         $response = sprintf("%s: %s in file %s on line %d%s\n",

--- a/src/Whoops/functions.php
+++ b/src/Whoops/functions.php
@@ -14,3 +14,12 @@ function isAjaxRequest()
         !empty($_SERVER['HTTP_X_REQUESTED_WITH'])
         && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
 }
+
+/**
+ * Check, if possible, that this execution was triggered by a command line.
+ * @return bool
+ */
+function isCommandLine()
+{
+    return PHP_SAPI == 'cli';
+}

--- a/tests/Whoops/Handler/PlainTextHandlerTest.php
+++ b/tests/Whoops/Handler/PlainTextHandlerTest.php
@@ -34,25 +34,19 @@ class PlainTextHandlerTest extends TestCase
      * @param  bool  $withTrace
      * @param  bool  $withTraceArgs
      * @param  bool  $loggerOnly
-     * @param  bool  $onlyForCommandLine
-     * @param  bool  $outputOnlyIfCommandLine
      * @return array
      */
     private function getPlainTextFromHandler(
         $withTrace = false,
         $withTraceArgs = false,
         $traceFunctionArgsOutputLimit = 1024,
-        $loggerOnly = false,
-        $onlyForCommandLine = false,
-        $outputOnlyIfCommandLine = true
+        $loggerOnly = false
     ) {
         $handler = $this->getHandler();
         $handler->addTraceToOutput($withTrace);
         $handler->addTraceFunctionArgsToOutput($withTraceArgs);
         $handler->setTraceFunctionArgsOutputLimit($traceFunctionArgsOutputLimit);
         $handler->loggerOnly($loggerOnly);
-        $handler->onlyForCommandLine($onlyForCommandLine);
-        $handler->outputOnlyIfCommandLine($outputOnlyIfCommandLine);
 
         $run = $this->getRunInstance();
         $run->pushHandler($handler);
@@ -165,64 +159,6 @@ class PlainTextHandlerTest extends TestCase
     }
 
     /**
-     * @covers Whoops\Handler\PlainTextHandler::onlyForCommandLine
-     */
-    public function testOnlyForCommandLine()
-    {
-        $handler = $this->getHandler();
-
-        $handler->onlyForCommandLine(true);
-        $this->assertEquals(true, $handler->onlyForCommandLine());
-
-        $handler->onlyForCommandLine(false);
-        $this->assertEquals(false, $handler->onlyForCommandLine());
-
-        $handler->onlyForCommandLine(null);
-        $this->assertEquals(null, $handler->onlyForCommandLine());
-
-        $handler->onlyForCommandLine(1);
-        $this->assertEquals(true, $handler->onlyForCommandLine());
-
-        $handler->onlyForCommandLine(0);
-        $this->assertEquals(false, $handler->onlyForCommandLine());
-
-        $handler->onlyForCommandLine('');
-        $this->assertEquals(false, $handler->onlyForCommandLine());
-
-        $handler->onlyForCommandLine('false');
-        $this->assertEquals(true, $handler->onlyForCommandLine());
-    }
-
-    /**
-     * @covers Whoops\Handler\PlainTextHandler::outputOnlyIfCommandLine
-     */
-    public function testOutputOnlyIfCommandLine()
-    {
-        $handler = $this->getHandler();
-
-        $handler->outputOnlyIfCommandLine(true);
-        $this->assertEquals(true, $handler->outputOnlyIfCommandLine());
-
-        $handler->outputOnlyIfCommandLine(false);
-        $this->assertEquals(false, $handler->outputOnlyIfCommandLine());
-
-        $handler->outputOnlyIfCommandLine(null);
-        $this->assertEquals(null, $handler->outputOnlyIfCommandLine());
-
-        $handler->outputOnlyIfCommandLine(1);
-        $this->assertEquals(true, $handler->outputOnlyIfCommandLine());
-
-        $handler->outputOnlyIfCommandLine(0);
-        $this->assertEquals(false, $handler->outputOnlyIfCommandLine());
-
-        $handler->outputOnlyIfCommandLine('');
-        $this->assertEquals(false, $handler->outputOnlyIfCommandLine());
-
-        $handler->outputOnlyIfCommandLine('false');
-        $this->assertEquals(true, $handler->outputOnlyIfCommandLine());
-    }
-
-    /**
      * @covers Whoops\Handler\PlainTextHandler::loggerOnly
      */
     public function testLoggerOnly()
@@ -261,9 +197,7 @@ class PlainTextHandlerTest extends TestCase
             $withTrace = false,
             $withTraceArgs = true,
             $traceFunctionArgsOutputLimit = 1024,
-            $loggerOnly = false,
-            $onlyForCommandLine = false,
-            $outputOnlyIfCommandLine = true
+            $loggerOnly = false
         );
 
         // Check that the response has the correct value:
@@ -283,7 +217,6 @@ class PlainTextHandlerTest extends TestCase
     /**
      * @covers Whoops\Handler\PlainTextHandler::addTraceToOutput
      * @covers Whoops\Handler\PlainTextHandler::getTraceOutput
-     * @covers Whoops\Handler\PlainTextHandler::canProcess
      * @covers Whoops\Handler\PlainTextHandler::canOutput
      * @covers Whoops\Handler\PlainTextHandler::handle
      */
@@ -293,9 +226,7 @@ class PlainTextHandlerTest extends TestCase
             $withTrace = true,
             $withTraceArgs = false,
             $traceFunctionArgsOutputLimit = 1024,
-            $loggerOnly = false,
-            $onlyForCommandLine = false,
-            $outputOnlyIfCommandLine = true
+            $loggerOnly = false
         );
 
         $lines = explode("\n", $text);
@@ -311,7 +242,7 @@ class PlainTextHandlerTest extends TestCase
                 'Whoops\Handler\PlainTextHandlerTest',
                 'getException',
                 __FILE__,
-                61
+                55
             ),
             $lines[3]
         );
@@ -322,7 +253,6 @@ class PlainTextHandlerTest extends TestCase
      * @covers Whoops\Handler\PlainTextHandler::addTraceFunctionArgsToOutput
      * @covers Whoops\Handler\PlainTextHandler::getTraceOutput
      * @covers Whoops\Handler\PlainTextHandler::getFrameArgsOutput
-     * @covers Whoops\Handler\PlainTextHandler::canProcess
      * @covers Whoops\Handler\PlainTextHandler::canOutput
      * @covers Whoops\Handler\PlainTextHandler::handle
      */
@@ -332,9 +262,7 @@ class PlainTextHandlerTest extends TestCase
             $withTrace = true,
             $withTraceArgs = true,
             $traceFunctionArgsOutputLimit = 2048,
-            $loggerOnly = false,
-            $onlyForCommandLine = false,
-            $outputOnlyIfCommandLine = true
+            $loggerOnly = false
         );
 
         $lines = explode("\n", $text);
@@ -353,7 +281,7 @@ class PlainTextHandlerTest extends TestCase
                 'Whoops\Handler\PlainTextHandlerTest',
                 'getException',
                 __FILE__,
-                61
+                55
             ),
             $lines[8]
         );
@@ -372,7 +300,6 @@ class PlainTextHandlerTest extends TestCase
      * @covers Whoops\Handler\PlainTextHandler::addTraceFunctionArgsToOutput
      * @covers Whoops\Handler\PlainTextHandler::getTraceOutput
      * @covers Whoops\Handler\PlainTextHandler::getFrameArgsOutput
-     * @covers Whoops\Handler\PlainTextHandler::canProcess
      * @covers Whoops\Handler\PlainTextHandler::canOutput
      * @covers Whoops\Handler\PlainTextHandler::handle
      */
@@ -382,9 +309,7 @@ class PlainTextHandlerTest extends TestCase
             $withTrace = true,
             $withTraceArgs = 3,
             $traceFunctionArgsOutputLimit = 1024,
-            $loggerOnly = false,
-            $onlyForCommandLine = false,
-            $outputOnlyIfCommandLine = true
+            $loggerOnly = false
         );
 
         $lines = explode("\n", $text);
@@ -400,7 +325,7 @@ class PlainTextHandlerTest extends TestCase
                 'Whoops\Handler\PlainTextHandlerTest',
                 'getException',
                 __FILE__,
-                61
+                55
             ),
             $lines[8]
         );
@@ -417,7 +342,6 @@ class PlainTextHandlerTest extends TestCase
 
     /**
      * @covers Whoops\Handler\PlainTextHandler::loggerOnly
-     * @covers Whoops\Handler\PlainTextHandler::canProcess
      * @covers Whoops\Handler\PlainTextHandler::handle
      */
     public function testReturnsWithLoggerOnlyOutput()
@@ -426,9 +350,7 @@ class PlainTextHandlerTest extends TestCase
             $withTrace = true,
             $withTraceArgs = true,
             $traceFunctionArgsOutputLimit = 1024,
-            $loggerOnly = true,
-            $onlyForCommandLine = false,
-            $outputOnlyIfCommandLine = true
+            $loggerOnly = true
         );
         // Check that the response has the correct value:
         $this->assertEquals('', $text);


### PR DESCRIPTION
…). Added Whoops\isCommandLine() as a more flexible successor.

The actual great thing about this change is, that we drop a lot of unecessary api but staying as flexible as before.

fixes #335