### PR TITLE
Use rounded corners for frame-index.

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -140,7 +140,8 @@ header {
       height: 18px;
       width: 18px;
       line-height: 18px;
-      border-radius: 100%;
+      border-radius: 5px;
+      padding: 0 1px 0 1px;
       text-align: center;
       display: inline-block;
     }


### PR DESCRIPTION
Personally I think the circles used around the frame-index are not consistent with the rest of the new layout. In all other places we use rectangles with rounded corners.

This PR also introduces small rectangles instead of the circles.

BEFORE
![round](https://cloud.githubusercontent.com/assets/120441/11457973/aadeaa1e-96b7-11e5-85b4-a4ba2da5367d.png)

AFTER
![rounded](https://cloud.githubusercontent.com/assets/120441/11457974/af0c7c42-96b7-11e5-8e8d-88ee6e268e72.png)

