### PR TITLE
Fix handling of Content-Type headers

### DIFF
--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -258,8 +258,7 @@ class PlainTextHandler extends Handler
             return Handler::DONE;
         }
 
-        if (class_exists('\Whoops\Util\Misc')
-            && \Whoops\Util\Misc::canSendHeaders()) {
+        if (\Whoops\Util\Misc::canSendHeaders()) {
             header('Content-Type: text/plain');
         }
 

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -185,6 +185,10 @@ class PrettyPageHandler extends Handler
         }, $this->getDataTables());
         $vars["tables"] = array_merge($extraTables, $vars["tables"]);
 
+        if (\Whoops\Util\Misc::canSendHeaders()) {
+            header('Content-Type: text/html');
+        }
+
         $helper->setVariables($vars);
         $helper->render($templateFile);
 


### PR DESCRIPTION
There was previously a seemingly redundant check for the existence of `\Whoops\Utils\Misc` in `PlainTextHandler`; I've purged it, although perhaps there's some logic to it that I'm not seeing?

I've also made the `PrettyPageHandler` spit out `Content-Type: text/html` so that if I cause an error after I've already emitted another `Content-Type` header, the pretty HTML error page can still render.