### PR TITLE
Fix for PHP7

### DIFF
--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -157,10 +157,10 @@ class Inspector
      *
      * If xdebug is installed
      *
-     * @param Exception $e
+     * @param  \Throwable $exception
      * @return array
      */
-    protected function getTrace(\Exception $e)
+    protected function getTrace($e)
     {
         $traces = $e->getTrace();
 

--- a/tests/Whoops/Exception/InspectorTest.php
+++ b/tests/Whoops/Exception/InspectorTest.php
@@ -45,6 +45,19 @@ class InspectorTest extends TestCase
     }
 
     /**
+     * @covers Whoops\Exception\Inspector::getFrames
+     */
+    public function testDoesNotFailOnPHP7ErrorObject()
+    {
+        if (class_exists('Error')) {
+            $inner = new \Error('inner');
+            $outer = $this->getException('outer', 0, $inner);
+            $inspector = $this->getInspectorInstance($outer);
+            $frames = $inspector->getFrames();
+            $this->assertSame($outer->getLine(), $frames[0]->getLine());
+        }
+    }
+    /**
      * @covers Whoops\Exception\Inspector::getExceptionName
      */
     public function testReturnsCorrectExceptionName()

--- a/tests/Whoops/Exception/InspectorTest.php
+++ b/tests/Whoops/Exception/InspectorTest.php
@@ -49,13 +49,17 @@ class InspectorTest extends TestCase
      */
     public function testDoesNotFailOnPHP7ErrorObject()
     {
-        if (class_exists('Error')) {
-            $inner = new \Error('inner');
-            $outer = $this->getException('outer', 0, $inner);
-            $inspector = $this->getInspectorInstance($outer);
-            $frames = $inspector->getFrames();
-            $this->assertSame($outer->getLine(), $frames[0]->getLine());
+        if (!class_exists('Error')) {
+            $this->markTestSkipped(
+              'PHP 5.x, the Error class is not available.'
+            );
         }
+
+        $inner = new \Error('inner');
+        $outer = $this->getException('outer', 0, $inner);
+        $inspector = $this->getInspectorInstance($outer);
+        $frames = $inspector->getFrames();
+        $this->assertSame($outer->getLine(), $frames[0]->getLine());
     }
     /**
      * @covers Whoops\Exception\Inspector::getExceptionName


### PR DESCRIPTION
Fixes `Whoops\Exception\ErrorException: Uncaught TypeError: Argument 1 passed to Whoops\Exception\Inspector::getTrace() must be an instance of Exception, instance of Error given`