### PR TITLE
Allow PHPUnit 5.0 as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "phpunit/phpunit": "^4.8"
+        "php": ">=5.5"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.8 || ^5.0",
         "mockery/mockery": "0.9.*"
     },
     "suggest": {


### PR DESCRIPTION
Updated to PHPUnit 5.0 and moved it to require-dev.