### PR TITLE
Remove the final restriction on Whoops\Run

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -14,7 +14,7 @@ use Whoops\Handler\Handler;
 use Whoops\Handler\HandlerInterface;
 use Whoops\Util\Misc;
 
-final class Run
+class Run
 {
     const EXCEPTION_HANDLER = "handleException";
     const ERROR_HANDLER     = "handleError";


### PR DESCRIPTION
Allows other libraries, frameworks and projects to mock `Whoops\Run` by removing its `final` restriction.

If extending the class is *really* not recommended, I'd favor a big comment on the `README` instead of the `final` keyword.