### PR TITLE
Added Sublime Text 3 "subl" protocol support

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -348,9 +348,8 @@ class PrettyPageHandler extends Handler
         $editor['url'] = str_replace("%file", rawurlencode($filePath), $editor['url']);
 
         // The "%raw_file" will always use unix style paths. (even on Windows)
-        $f = str_replace('\\', '/', $filePath);
-        // Don't encode the file path for RAW.
-        $editor['url'] = str_replace("%raw_file", $f, $editor['url']);
+        // Also, don't url-encode the file path for RAW.
+        $editor['url'] = str_replace("%raw_file", str_replace('\\', '/', $filePath), $editor['url']);
 
         return $editor['url'];
     }

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -70,6 +70,7 @@ class PrettyPageHandler extends Handler
      */
     protected $editors = array(
         "sublime"  => "subl://open?url=file://%file&line=%line",
+        "sublime3"  => "subl://%raw_file:%line",
         "textmate" => "txmt://open?url=file://%file&line=%line",
         "emacs"    => "emacs://open?url=file://%file&line=%line",
         "macvim"   => "mvim://open/?url=file://%file&line=%line",
@@ -345,6 +346,11 @@ class PrettyPageHandler extends Handler
 
         $editor['url'] = str_replace("%line", rawurlencode($line), $editor['url']);
         $editor['url'] = str_replace("%file", rawurlencode($filePath), $editor['url']);
+
+        // The "%raw_file" will always use unix style paths. (even on Windows)
+        $f = str_replace('\\', '/', $filePath);
+        // Don't encode the file path for RAW.
+        $editor['url'] = str_replace("%raw_file", $f, $editor['url']);
 
         return $editor['url'];
     }


### PR DESCRIPTION
Updated to support the protocol for the SUBL PROTOCOL package.
This particular protocol must use the raw (unencoded) file path, as well as *nix style line endings (even on Windows).
see: https://packagecontrol.io/packages/subl%20protocol