### PR TITLE
Dump frame arguments below the source code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.0",
-        "mockery/mockery": "0.9.*"
+        "mockery/mockery": "0.9.*",
+        "symfony/var-dumper": "~3.0"
     },
     "suggest": {
         "symfony/var-dumper": "Pretty print complex values better with var-dumper available",

--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -136,6 +136,15 @@ header {
       font-size: 14px;
     }
 
+    .frame-arg {
+      margin-left: 20px;
+      display: block;
+    }
+
+    .frame-arg-separated .sf-dump::after {
+      content: ',';
+    }
+
     .frame-index {
       font-size: 11px;
       color: #a29d9d;

--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -94,6 +94,26 @@ header {
       border-bottom: 1px solid rgba(0, 0, 0, .1);
     }
 
+    .details pre.sf-dump {
+      white-space: pre;
+      word-wrap: inherit;
+    }
+
+    .details pre.sf-dump,
+    .details pre.sf-dump .sf-dump-num,
+    .details pre.sf-dump .sf-dump-const,
+    .details pre.sf-dump .sf-dump-str,
+    .details pre.sf-dump .sf-dump-note,
+    .details pre.sf-dump .sf-dump-ref,
+    .details pre.sf-dump .sf-dump-public,
+    .details pre.sf-dump .sf-dump-protected,
+    .details pre.sf-dump .sf-dump-private,
+    .details pre.sf-dump .sf-dump-meta,
+    .details pre.sf-dump .sf-dump-key,
+    .details pre.sf-dump .sf-dump-index {
+      color: #463C54;
+    }
+
 .left-panel {
   height: 100%;
   overflow: auto;

--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -136,15 +136,6 @@ header {
       font-size: 14px;
     }
 
-    .frame-arg {
-      margin-left: 20px;
-      display: block;
-    }
-
-    .frame-arg-separated .sf-dump::after {
-      content: ',';
-    }
-
     .frame-index {
       font-size: 11px;
       color: #a29d9d;
@@ -322,7 +313,7 @@ pre .xsl, code .xsl { color: #d0a0d0; }  /* xslt tag */
 pre .atn, code .atn { color: #ef7c61; font-weight: normal;} /* html/xml attribute name */
 pre .atv, code .atv { color: #bcd42a; }  /* html/xml attribute value  */
 pre .dec, code .dec { color: #606; }  /* decimal  */
-pre.prettyprint, code.prettyprint {
+pre.prettyprint, code.prettyprint, .frame-args.prettyprint, .frame-args.prettyprint samp {
   font-family: "Inconsolata", "Fira Mono", "Source Code Pro", Monaco, Consolas, "Lucida Console", monospace;
   background: #333;
   color: #e9e4e5;

--- a/src/Whoops/Resources/js/whoops.base.js
+++ b/src/Whoops/Resources/js/whoops.base.js
@@ -119,4 +119,10 @@ Zepto(function($) {
     e.preventDefault();
     $.get(this.href);
   });
+
+  // Symfony VarDumper: Close the by default expanded objects
+  $('.sf-dump-expanded')
+    .removeClass('sf-dump-expanded')
+    .addClass('sf-dump-compact');
+  $('.sf-dump-toggle span').html('&#9654;');
 });

--- a/src/Whoops/Resources/views/env_details.html.php
+++ b/src/Whoops/Resources/views/env_details.html.php
@@ -17,7 +17,7 @@
             <?php foreach ($data as $k => $value): ?>
               <tr>
                 <td><?php echo $tpl->escape($k) ?></td>
-                <td><?php echo $tpl->escape($tpl->dump($value)) ?></td>
+                <td><?php echo $tpl->dump($value) ?></td>
               </tr>
             <?php endforeach ?>
             </table>

--- a/src/Whoops/Resources/views/frame_code.html.php
+++ b/src/Whoops/Resources/views/frame_code.html.php
@@ -47,6 +47,16 @@
           <?php endif ?>
         <?php endif ?>
 
+        <?php $frameArgs = $tpl->dumpArgs($frame); ?>
+        <?php if ($frameArgs): ?>
+          <div class="frame-file">
+              Arguments
+          </div>
+          <div class="code-block frame-args prettyprint">
+              <?php echo $frameArgs; ?>
+          </div>
+        <?php endif ?>
+
         <?php
           // Append comments for this frame
           $comments = $frame->getComments();

--- a/src/Whoops/Resources/views/frame_list.html.php
+++ b/src/Whoops/Resources/views/frame_list.html.php
@@ -7,7 +7,6 @@
         <span class="frame-index"><?php echo (count($frames) - $i - 1) ?></span>
         <span class="frame-class"><?php echo $tpl->escape($frame->getClass() ?: '') ?></span>
         <span class="frame-function"><?php echo $tpl->escape($frame->getFunction() ?: '') ?></span>
-        <?php echo $tpl->dumpArgs($frame); ?>
       </div>
 
     <span class="frame-file">

--- a/src/Whoops/Resources/views/frame_list.html.php
+++ b/src/Whoops/Resources/views/frame_list.html.php
@@ -7,6 +7,7 @@
         <span class="frame-index"><?php echo (count($frames) - $i - 1) ?></span>
         <span class="frame-class"><?php echo $tpl->escape($frame->getClass() ?: '') ?></span>
         <span class="frame-function"><?php echo $tpl->escape($frame->getFunction() ?: '') ?></span>
+        <?php echo $tpl->dumpArgs($frame); ?>
       </div>
 
     <span class="frame-file">
@@ -14,4 +15,4 @@
    --><span class="frame-line"><?php echo (int) $frame->getLine() ?></span>
     </span>
   </div>
-<?php endforeach ?>
+<?php endforeach; ?>

--- a/src/Whoops/Util/HtmlDumperOutput.php
+++ b/src/Whoops/Util/HtmlDumperOutput.php
@@ -6,6 +6,11 @@
 
 namespace Whoops\Util;
 
+/**
+ * Used as output callable for Symfony\Component\VarDumper\Dumper\HtmlDumper::dump()
+ *
+ * @see TemplateHelper::dump()
+ */
 class HtmlDumperOutput
 {
     private $output;

--- a/src/Whoops/Util/HtmlDumperOutput.php
+++ b/src/Whoops/Util/HtmlDumperOutput.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Whoops - php errors for cool kids
+ * @author Filipe Dobreira <http://github.com/filp>
+ */
+
+namespace Whoops\Util;
+
+class HtmlDumperOutput
+{
+    private $output;
+
+    public function __invoke($line, $depth)
+    {
+        // A negative depth means "end of dump"
+        if ($depth >= 0) {
+            // Adds a two spaces indentation to the line
+            $this->output .= str_repeat('  ', $depth) . $line . "\n";
+        }
+    }
+
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    public function clear()
+    {
+        $this->output = null;
+    }
+
+}

--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -23,6 +23,11 @@ class TemplateHelper
     private $variables = array();
 
     /**
+     * @var HtmlDumper
+     */
+    private $htmlDumper;
+
+    /**
      * Escapes a string for output in an HTML document
      *
      * @param  string $raw
@@ -65,11 +70,9 @@ class TemplateHelper
 
     private function getDumper()
     {
-        static $dumper = null;
-
-        if (!$dumper && class_exists('Symfony\Component\VarDumper\Cloner\VarCloner')) {
+        if (!$this->htmlDumper && class_exists('Symfony\Component\VarDumper\Cloner\VarCloner')) {
             // re-use the same var-dumper instance, so it won't re-render the global styles/scripts on each dump.
-            $dumper = new HtmlDumper();
+            $this->htmlDumper = new HtmlDumper();
 
             $styles = array(
                 'default' => '',
@@ -85,10 +88,10 @@ class TemplateHelper
                 'key' => '',
                 'index' => '',
             );
-            $dumper->setStyles($styles);
+            $this->htmlDumper->setStyles($styles);
         }
 
-        return $dumper;
+        return $this->htmlDumper;
     }
 
     /**

--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -80,18 +80,18 @@ class TemplateHelper
             $this->htmlDumper = new HtmlDumper($this->htmlDumperOutput);
 
             $styles = array(
-                'default' => '',
-                'num' => '',
-                'const' => '',
-                'str' => '',
-                'note' => '',
-                'ref' => '',
-                'public' => '',
-                'protected' => '',
-                'private' => '',
-                'meta' => '',
-                'key' => '',
-                'index' => '',
+                'default' => 'color:#FFFFFF; line-height:normal; font:12px "Inconsolata", "Fira Mono", "Source Code Pro", Monaco, Consolas, "Lucida Console", monospace !important; word-wrap: break-word; white-space: pre-wrap; position:relative; z-index:99999; word-break: normal',
+                'num' => 'color:#BCD42A',
+                'const' => 'color: #4bb1b1;',
+                'str' => 'color:#BCD42A',
+                'note' => 'color:#ef7c61',
+                'ref' => 'color:#A0A0A0',
+                'public' => 'color:#FFFFFF',
+                'protected' => 'color:#FFFFFF',
+                'private' => 'color:#FFFFFF',
+                'meta' => 'color:#FFFFFF',
+                'key' => 'color:#BCD42A',
+                'index' => 'color:#ef7c61',
             );
             $this->htmlDumper->setStyles($styles);
         }

--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -7,7 +7,6 @@
 namespace Whoops\Util;
 
 use Symfony\Component\VarDumper\Cloner\VarCloner;
-use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Whoops\Exception\Frame;
 

--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -141,15 +141,11 @@ class TemplateHelper
         $numFrames = count($frame->getArgs());
 
         if ($numFrames > 0) {
-            $html .= '(';
+            $html = '<ol class="linenums">';
             foreach($frame->getArgs() as $j => $frameArg) {
-                $class = 'frame-arg';
-                if ($j != $numFrames - 1 ) {
-                    $class .= ' frame-arg-separated';
-                }
-                $html .= '<span class="'. $class .'">'. $this->dump($frameArg) .'</span>';
+                $html .= '<li>'. $this->dump($frameArg) .'</li>';
             }
-            $html .= ')';
+            $html .= '</ol>';
         }
 
         return $html;


### PR DESCRIPTION
This builds on top of #337, but dumps the arguments below the source code (similar to #384).

Collapsed by default:
http://imgur.com/9augmq7
Expand second argument:
http://imgur.com/oXfrSfa
Expand first and second argument:
http://imgur.com/JJQ1oF0
No arguments:
http://imgur.com/uWVch0e