### PR TITLE
Cache composer packages and secure PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,20 @@
 language: php
 
 php:
-  - 5.5.9
-  - 5.5
-  - 5.6
-  - 7.0
+  - '5.5.9'
+  - '5.5'
+  - '5.6'
+  - '7.0'
   - hhvm
 
 sudo: false
 
+cache:
+  directories:
+    - "$HOME/.composer/cache"
+
 before_script:
-  - composer install --no-interaction --prefer-source
+  - composer install --no-interaction --prefer-dist
   - if [ $TRAVIS_PHP_VERSION = "5.6" ]; then PHPUNIT_FLAGS="--coverage-clover build/logs/clover.xml"; fi
 
 script:


### PR DESCRIPTION
For PHP version quotes, it looks like it was a mistake on the Travis team side not to include them in the doc (they changed it now), as without them, versions are interpreted as numbers instead of strings which can cause some issues (it did for some versions of nodejs). For the whole discussion thread, you can check https://github.com/api-platform/core/pull/449#discussion_r55392343.

The other change is simply installing the dist packages (lighter, so faster) and caching them to speed up the `composer install`.