### PR TITLE
Custom inspector

### DIFF
--- a/docs/API Documentation.md
+++ b/docs/API Documentation.md
@@ -138,9 +138,9 @@ Inspector::__construct(Exception $exception)
 Inspector::getException()
  #=> Exception
 
-// Returns the string name of the Exception being inspected
+// Returns the name of the class of the Exception being inspected
 // A faster way of doing get_class($inspector->getException())
-Inspector::getExceptionName()
+Inspector::getClass()
  #=> string
 
 // Returns the string message for the Exception being inspected

--- a/docs/API Documentation.md
+++ b/docs/API Documentation.md
@@ -145,7 +145,7 @@ Inspector::getClass()
 
 // Returns the string message for the Exception being inspected
 // A faster way of doing $inspector->getException()->getMessage()
-Inspector::getExceptionMessage()
+Inspector::getMessage()
  #=> string
 
 // Returns an iterator instance for all the frames in the stack

--- a/src/Whoops/Exception/Formatter.php
+++ b/src/Whoops/Exception/Formatter.php
@@ -18,12 +18,11 @@ class Formatter
      */
     public static function formatExceptionAsDataArray(Inspector $inspector, $shouldAddTrace)
     {
-        $exception = $inspector->getException();
         $response = array(
-            'type'    => get_class($exception),
-            'message' => $exception->getMessage(),
-            'file'    => $exception->getFile(),
-            'line'    => $exception->getLine(),
+            'type'    => $inspector->getClass(),
+            'message' => $inspector->getMessage(),
+            'file'    => $inspector->getFile(),
+            'line'    => $inspector->getLine(),
         );
 
         if ($shouldAddTrace) {
@@ -49,12 +48,11 @@ class Formatter
 
     public static function formatExceptionPlain(Inspector $inspector)
     {
-        $message = $inspector->getException()->getMessage();
         $frames = $inspector->getFrames();
 
         $plain = $inspector->getClass();
         $plain .= ' thrown with message "';
-        $plain .= $message;
+        $plain .= $inspector->getMessage();
         $plain .= '"'."\n\n";
 
         $plain .= "Stacktrace:\n";

--- a/src/Whoops/Exception/Formatter.php
+++ b/src/Whoops/Exception/Formatter.php
@@ -52,7 +52,7 @@ class Formatter
         $message = $inspector->getException()->getMessage();
         $frames = $inspector->getFrames();
 
-        $plain = $inspector->getExceptionName();
+        $plain = $inspector->getClass();
         $plain .= ' thrown with message "';
         $plain .= $message;
         $plain .= '"'."\n\n";

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -81,6 +81,36 @@ class Inspector
         return $this->exception->getMessage();
     }
 
+    /**
+     * @return int
+     */
+    public function getCode()
+    {
+        if ($this->exception instanceof \ErrorException) {
+            // ErrorExceptions wrap the php-error types within the "severity" property
+            return Misc::translateErrorCode($this->exception->getSeverity());
+        }
+
+        return $this->exception->getCode();
+    }
+
+    /**
+     * @return string
+     */
+    public function getFile()
+    {
+        return $this->exception->getFile();
+    }
+
+    /**
+     * @return int
+     */
+    public function getLine()
+    {
+        return $this->exception->getLine();
+    }
+
+    /**
      * Does the wrapped Exception has a previous Exception?
      * @return bool
      */

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -42,7 +42,11 @@ class Inspector
     }
 
     /**
+     * Use getClass.
+     *
      * @return string
+     *
+     * @deprecated
      */
     public function getExceptionName()
     {
@@ -58,6 +62,13 @@ class Inspector
     }
 
     /**
+     * @return string
+     */
+    public function getClass()
+    {
+        return get_class($this->exception);
+    }
+
      * Does the wrapped Exception has a previous Exception?
      * @return bool
      */

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -54,7 +54,11 @@ class Inspector
     }
 
     /**
+     * Use getMessage.
+     *
      * @return string
+     *
+     * @deprecated
      */
     public function getExceptionMessage()
     {
@@ -67,6 +71,14 @@ class Inspector
     public function getClass()
     {
         return get_class($this->exception);
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->exception->getMessage();
     }
 
      * Does the wrapped Exception has a previous Exception?
@@ -151,7 +163,7 @@ class Inspector
                 // I assume it will always be set, but let's be safe
                 if (isset($newFrames[0])) {
                     $newFrames[0]->addComment(
-                        $previousInspector->getExceptionMessage(),
+                        $previousInspector->getMessage(),
                         'Exception message:'
                     );
                 }

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -13,17 +13,17 @@ class Inspector
     /**
      * @var \Throwable
      */
-    private $exception;
+    protected $exception;
 
     /**
      * @var \Whoops\Exception\FrameCollection
      */
-    private $frames;
+    protected $frames;
 
     /**
      * @var \Whoops\Exception\Inspector
      */
-    private $previousExceptionInspector;
+    protected $previousExceptionInspector;
 
     /**
      * @param \Throwable $exception The exception to inspect
@@ -130,7 +130,7 @@ class Inspector
             $previousException = $this->exception->getPrevious();
 
             if ($previousException) {
-                $this->previousExceptionInspector = new Inspector($previousException);
+                $this->previousExceptionInspector = new static($previousException);
             }
         }
 

--- a/src/Whoops/Handler/CallbackHandler.php
+++ b/src/Whoops/Handler/CallbackHandler.php
@@ -40,13 +40,12 @@ class CallbackHandler extends Handler
      */
     public function handle()
     {
-        $exception = $this->getException();
         $inspector = $this->getInspector();
         $run       = $this->getRun();
         $callable  = $this->callable;
 
         // invoke the callable directly, to get simpler stacktraces (in comparison to call_user_func).
         // this assumes that $callable is a properly typed php-callable, which we check in __construct().
-        return $callable($exception, $inspector, $run);
+        return $callable($inspector->getException(), $inspector, $run);
     }
 }

--- a/src/Whoops/Handler/Handler.php
+++ b/src/Whoops/Handler/Handler.php
@@ -72,6 +72,8 @@ abstract class Handler implements HandlerInterface
 
     /**
      * @param \Throwable $exception
+     *
+     * @deprecated
      */
     public function setException($exception)
     {
@@ -79,7 +81,11 @@ abstract class Handler implements HandlerInterface
     }
 
     /**
+     * Get the exception via the inspector.
+     *
      * @return \Throwable
+     *
+     * @deprecated
      */
     protected function getException()
     {

--- a/src/Whoops/Handler/HandlerInterface.php
+++ b/src/Whoops/Handler/HandlerInterface.php
@@ -23,12 +23,6 @@ interface HandlerInterface
     public function setRun(Run $run);
 
     /**
-     * @param  \Throwable $exception
-     * @return void
-     */
-    public function setException($exception);
-
-    /**
      * @param  Inspector $inspector
      * @return void
      */

--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -240,13 +240,13 @@ class PlainTextHandler extends Handler
      */
     public function handle()
     {
-        $exception = $this->getException();
+        $inspector = $this->getInspector();
 
         $response = sprintf("%s: %s in file %s on line %d%s\n",
-                get_class($exception),
-                $exception->getMessage(),
-                $exception->getFile(),
-                $exception->getLine(),
+                $inspector->getClass(),
+                $inspector->getMessage(),
+                $inspector->getFile(),
+                $inspector->getLine(),
                 $this->getTraceOutput()
             );
 

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -130,13 +130,6 @@ class PrettyPageHandler extends Handler
         $inspector = $this->getInspector();
         $frames    = $inspector->getFrames();
 
-        $code = $inspector->getException()->getCode();
-
-        if ($inspector->getException() instanceof \ErrorException) {
-            // ErrorExceptions wrap the php-error types within the "severity" property
-            $code = Misc::translateErrorCode($inspector->getException()->getSeverity());
-        }
-
         // List of variables that will be passed to the layout template.
         $vars = array(
             "page_title" => $this->getPageTitle(),
@@ -154,9 +147,9 @@ class PrettyPageHandler extends Handler
             "env_details" => $this->getResource("views/env_details.html.php"),
 
             "title"          => $this->getPageTitle(),
-            "message"        => $inspector->getException()->getMessage(),
-            "code"           => $code,
             "name"           => explode("\\", $inspector->getClass()),
+            "message"        => $inspector->getMessage(),
+            "code"           => $inspector->getCode(),
             "plain_exception" => Formatter::formatExceptionPlain($inspector),
             "frames"         => $frames,
             "has_frames"     => !!count($frames),

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -154,9 +154,9 @@ class PrettyPageHandler extends Handler
             "env_details" => $this->getResource("views/env_details.html.php"),
 
             "title"          => $this->getPageTitle(),
-            "name"           => explode("\\", $inspector->getExceptionName()),
             "message"        => $inspector->getException()->getMessage(),
             "code"           => $code,
+            "name"           => explode("\\", $inspector->getClass()),
             "plain_exception" => Formatter::formatExceptionPlain($inspector),
             "frames"         => $frames,
             "has_frames"     => !!count($frames),

--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -35,6 +35,8 @@ final class Run implements RunInterface
 
     private $system;
 
+    protected $inspectorClass = Inspector::class;
+
     public function __construct(SystemFacade $system = null)
     {
         $this->system = $system ?: new SystemFacade;
@@ -101,7 +103,24 @@ final class Run implements RunInterface
      */
     private function getInspector($exception)
     {
-        return new Inspector($exception);
+        $class = $this->inspectorClass;
+        return new $class($exception);
+    }
+
+    /**
+     * Retun the class used to inspect the exceptions.
+     * @return string
+     */
+    public function getInspectorClass() {
+        return $this->inspectorClass;
+    }
+
+    /**
+     * Set the class used to inspect the exceptions.
+     * @return Run
+     */
+    public function setInspectorClass($class) {
+        $this->inspectorClass = $class;
     }
 
     /**

--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -251,12 +251,12 @@ final class Run implements RunInterface
         foreach (array_reverse($this->handlerStack) as $handler) {
             $handler->setRun($this);
             $handler->setInspector($inspector);
-            $handler->setException($exception);
 
-            // The HandlerInterface does not require an Exception passed to handle()
+            // The HandlerInterface does not require setException or an Exception passed to handle()
             // and neither of our bundled handlers use it.
             // However, 3rd party handlers may have already relied on this parameter,
             // and removing it would be possibly breaking for users.
+            $handler->setException($exception);
             $handlerResponse = $handler->handle($exception);
 
             if (in_array($handlerResponse, array(Handler::LAST_HANDLER, Handler::QUIT))) {

--- a/tests/Whoops/Exception/InspectorTest.php
+++ b/tests/Whoops/Exception/InspectorTest.php
@@ -62,14 +62,14 @@ class InspectorTest extends TestCase
         $this->assertSame($outer->getLine(), $frames[0]->getLine());
     }
     /**
-     * @covers Whoops\Exception\Inspector::getExceptionName
+     * @covers Whoops\Exception\Inspector::getClass
      */
-    public function testReturnsCorrectExceptionName()
+    public function testReturnsCorrectClass()
     {
         $exception = $this->getException();
         $inspector = $this->getInspectorInstance($exception);
 
-        $this->assertEquals(get_class($exception), $inspector->getExceptionName());
+        $this->assertEquals(get_class($exception), $inspector->getClass());
     }
 
     /**

--- a/tests/Whoops/Handler/CallbackHandlerTest.php
+++ b/tests/Whoops/Handler/CallbackHandlerTest.php
@@ -4,6 +4,7 @@ namespace Whoops\Handler;
 
 use Whoops\TestCase;
 use Whoops\Handler\CallbackHandler;
+use Whoops\Exception\Inspector;
 
 class CallbackHandlerTest extends TestCase
 {
@@ -11,6 +12,7 @@ class CallbackHandlerTest extends TestCase
         $handler = new CallbackHandler(function($exception, $inspector, $run) {
             return debug_backtrace();
         });
+        $handler->setInspector(new Inspector(new \Exception()));
         $backtrace = $handler->handle();
         
         foreach($backtrace as $frame) {


### PR DESCRIPTION
I've made the following backwards compatible changes:
- The bundled handlers only need and use the inspector, not the exception. This was discussed in #215.
- Allow subclasses of Inspector.
- Allow using your own Inspector in Run.

I need this because in production I'm storing [flattened](http://api.symfony.com/2.7/Symfony/Component/HttpKernel/Exception/FlattenException.html) exceptions in the database and I'm using my own inspector (for flattened exceptions) to generate the same pretty page as in development.
