### PR TITLE
Overwrite globals and canSendheaders

### DIFF
--- a/src/Whoops/Handler/Handler.php
+++ b/src/Whoops/Handler/Handler.php
@@ -8,6 +8,7 @@ namespace Whoops\Handler;
 
 use Whoops\Exception\Inspector;
 use Whoops\Run;
+use Whoops\Util\Misc;
 
 /**
  * Abstract implementation of a Handler.
@@ -37,6 +38,11 @@ abstract class Handler implements HandlerInterface
      * @var \Throwable $exception
      */
     private $exception;
+
+    /**
+     * @var bool
+     */
+    private $sendHeaders;
 
     /**
      * @param Run $run
@@ -84,5 +90,26 @@ abstract class Handler implements HandlerInterface
     protected function getException()
     {
         return $this->exception;
+    }
+
+    public function canSendHeaders()
+    {
+        if ($this->sendHeaders === null) {
+            $this->sendHeaders = Misc::canSendHeaders();
+        }
+
+        return $this->sendHeaders;
+    }
+
+    /**
+     * Allows to disable all attempts to dynamically decide whether to
+     * send headers.
+     * Set this to false to ensure that the handler will not send headers.
+     * @param  bool $value
+     * @return null
+     */
+    public function setSendHeaders($value)
+    {
+        $this->sendHeaders = (bool) $value;
     }
 }

--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -46,7 +46,7 @@ class JsonResponseHandler extends Handler
             ),
         );
 
-        if (\Whoops\Util\Misc::canSendHeaders()) {
+        if ($this->canSendHeaders()) {
             header('Content-Type: application/json');
         }
 

--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -258,7 +258,7 @@ class PlainTextHandler extends Handler
             return Handler::DONE;
         }
 
-        if (\Whoops\Util\Misc::canSendHeaders()) {
+        if ($this->canSendHeaders()) {
             header('Content-Type: text/plain');
         }
 

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -10,7 +10,6 @@ use InvalidArgumentException;
 use RuntimeException;
 use UnexpectedValueException;
 use Whoops\Exception\Formatter;
-use Whoops\Util\Misc;
 use Whoops\Util\TemplateHelper;
 
 class PrettyPageHandler extends Handler
@@ -192,7 +191,7 @@ class PrettyPageHandler extends Handler
         }, $this->getDataTables());
         $vars["tables"] = array_merge($extraTables, $vars["tables"]);
 
-        if (\Whoops\Util\Misc::canSendHeaders()) {
+        if ($this->canSendHeaders()) {
             header('Content-Type: text/html');
         }
 

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -53,6 +53,11 @@ class PrettyPageHandler extends Handler
     private $pageTitle = "Whoops! There was an error.";
 
     /**
+     * @var array[]
+     */
+    private $globalVariables = null;
+
+    /**
      * A string identifier for a known IDE/text editor, or a closure
      * that resolves a string that can be used to open a given file
      * in an editor. If the string contains the special substrings
@@ -137,6 +142,8 @@ class PrettyPageHandler extends Handler
             $code = Misc::translateErrorCode($inspector->getException()->getSeverity());
         }
 
+        $globalVariables = $this->getGlobalVariables();
+
         // List of variables that will be passed to the layout template.
         $vars = array(
             "page_title" => $this->getPageTitle(),
@@ -164,13 +171,13 @@ class PrettyPageHandler extends Handler
             "handlers"       => $this->getRun()->getHandlers(),
 
             "tables"      => array(
-                "GET Data"              => $_GET,
-                "POST Data"             => $_POST,
-                "Files"                 => $_FILES,
-                "Cookies"               => $_COOKIE,
-                "Session"               => isset($_SESSION) ? $_SESSION :  array(),
-                "Server/Request Data"   => $_SERVER,
-                "Environment Variables" => $_ENV,
+                "GET Data"              => $globalVariables["get"],
+                "POST Data"             => $globalVariables["post"],
+                "Files"                 => $globalVariables["files"],
+                "Cookies"               => $globalVariables["cookie"],
+                "Session"               => $globalVariables["session"],
+                "Server/Request Data"   => $globalVariables["server"],
+                "Environment Variables" => $globalVariables["env"],
             ),
         );
 
@@ -531,5 +538,38 @@ class PrettyPageHandler extends Handler
     public function setResourcesPath($resourcesPath)
     {
         $this->addResourcePath($resourcesPath);
+    }
+
+    /**
+     * Get the global variables.
+     *
+     * @return array
+     */
+    public function getGlobalVariables()
+    {
+        if (!$this->globalVariables) {
+            $this->globalVariables = $this->setGlobalVariables([]);
+        }
+        return $this->globalVariables;
+    }
+
+    /**
+     * Set the global variables.
+     *
+     * @param array $variables
+     */
+    public function setGlobalVariables($variables)
+    {
+        $defaults = [
+            "get"     => $_GET,
+            "post"    => $_POST,
+            "files"   => $_FILES,
+            "cookie"  => $_COOKIE,
+            "session" => isset($_SESSION) ? $_SESSION :  array(),
+            "server"  => $_SERVER,
+            "env"     => $_ENV
+        ];
+
+        $this->globalVariables = $variables + $defaults;
     }
 }


### PR DESCRIPTION
I've made 2 changes:
- Allow to manually set the globals in PrettyPageHandler. This way I can rebuild the pretty page from captured data (e.g. in database).
- Allow to manually set if the handler is allowed to send headers. This allows for better integration with a framework. E.g. I capture the output of the handlers and make a Symfony response from this.
