### PR TITLE
Remove all internals for objects not in the application namespaces

### DIFF
--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -6,6 +6,7 @@
 
 namespace Whoops\Util;
 
+use Symfony\Component\VarDumper\Cloner\ClonerInterface;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Whoops\Exception\Frame;
@@ -25,6 +26,11 @@ class TemplateHelper
      * @var HtmlDumper
      */
     private $htmlDumper;
+
+    /**
+     * @var ClonerInterface
+     */
+    private $cloner;
 
     /**
      * @var HtmlDumperOutput
@@ -110,10 +116,9 @@ class TemplateHelper
         $dumper = $this->getDumper();
 
         if ($dumper) {
-            $cloner = new VarCloner();
 
             // re-use the same DumpOutput instance, so it won't re-render the global styles/scripts on each dump.
-            $dumper->dump($cloner->cloneVar($value), $this->htmlDumperOutput);
+            $dumper->dump($this->cloner->cloneVar($value), $this->htmlDumperOutput);
 
             $output = $this->htmlDumperOutput->getOutput();
             $this->htmlDumperOutput->clear();
@@ -243,5 +248,29 @@ class TemplateHelper
     public function getVariables()
     {
         return $this->variables;
+    }
+
+    /**
+     * Set the cloner used for dumping variables.
+     *
+     * @param ClonerInterface $cloner
+     */
+    public function setCloner($cloner)
+    {
+        $this->cloner = $cloner;
+    }
+
+    /**
+     * Get the cloner used for dumping variables.
+     * 
+     * @return ClonerInterface
+     */
+    public function getCloner()
+    {
+        if (!$this->cloner) {
+            $this->cloner = new VarCloner();
+        }
+
+        return $this->cloner;
     }
 }


### PR DESCRIPTION
Dumping the frame arguments is very useful, but can make the response very big. For instance, in a vanilla Laravel setup the page becomes 14.5mb. 14mb comes from dumping Laravel internals (like the Router) and Closures that use those objects. This information isn't useful, so it's ok to hide it.

This change will optionally (if PrettyPageHandler::$applicationNamespaces are defined) remove all internals for objects that are not defined in the application (e.g. framework objects). For Laravel, this brings the response for Laravel back to 300-400k. This can be further reduced by cutting all internals of Closures (now it will still show some basic information), but I assume this little overhead is probably ok.