### PR TITLE
Don't dump object internals

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -8,6 +8,8 @@ namespace Whoops\Handler;
 
 use InvalidArgumentException;
 use RuntimeException;
+use Symfony\Component\VarDumper\Cloner\AbstractCloner;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
 use UnexpectedValueException;
 use Whoops\Exception\Formatter;
 use Whoops\Util\Misc;
@@ -116,6 +118,23 @@ class PrettyPageHandler extends Handler
 
         // @todo: Make this more dynamic
         $helper = new TemplateHelper();
+
+        $cloner = new VarCloner();
+        // Only dump object internals if a custom caster exists.
+        $cloner->addCasters(['*' => function ($obj, $a, $stub, $isNested, $filter = 0) {
+            $class = $stub->class;
+            $classes = [$class => $class] + class_parents($class) + class_implements($class);
+
+            foreach ($classes as $class) {
+                if (isset(AbstractCloner::$defaultCasters[$class])) {
+                    return $a;
+                }
+            }
+
+            // Remove all internals
+            return [];
+        }]);
+        $helper->setCloner($cloner);
 
         $templateFile = $this->getResource("views/layout.html.php");
         $cssFile      = $this->getResource("css/whoops.base.css");

--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -6,6 +6,7 @@
 
 namespace Whoops\Util;
 
+use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Cloner\AbstractCloner;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
@@ -117,8 +118,9 @@ class TemplateHelper
 
         if ($dumper) {
             // re-use the same DumpOutput instance, so it won't re-render the global styles/scripts on each dump.
+            // exclude verbose information (e.g. exception stack traces)
             $dumper->dump(
-                $this->getCloner()->cloneVar($value),
+                $this->getCloner()->cloneVar($value, Caster::EXCLUDE_VERBOSE),
                 $this->htmlDumperOutput
             );
 

--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -6,6 +6,7 @@
 
 namespace Whoops\Util;
 
+use Symfony\Component\VarDumper\Cloner\AbstractCloner;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Whoops\Exception\Frame;
@@ -30,6 +31,11 @@ class TemplateHelper
      * @var HtmlDumperOutput
      */
     private $htmlDumperOutput;
+
+    /**
+     * @var AbstractCloner
+     */
+    private $cloner;
 
     /**
      * Escapes a string for output in an HTML document
@@ -110,10 +116,11 @@ class TemplateHelper
         $dumper = $this->getDumper();
 
         if ($dumper) {
-            $cloner = new VarCloner();
-
             // re-use the same DumpOutput instance, so it won't re-render the global styles/scripts on each dump.
-            $dumper->dump($cloner->cloneVar($value), $this->htmlDumperOutput);
+            $dumper->dump(
+                $this->getCloner()->cloneVar($value),
+                $this->htmlDumperOutput
+            );
 
             $output = $this->htmlDumperOutput->getOutput();
             $this->htmlDumperOutput->clear();
@@ -243,5 +250,28 @@ class TemplateHelper
     public function getVariables()
     {
         return $this->variables;
+    }
+
+    /**
+     * Set the cloner used for dumping variables.
+     *
+     * @param AbstractCloner $cloner
+     */
+    public function setCloner($cloner)
+    {
+        $this->cloner = $cloner;
+    }
+
+    /**
+     * Get the cloner used for dumping variables.
+     *
+     * @return AbstractCloner
+     */
+    public function getCloner()
+    {
+        if (!$this->cloner) {
+            $this->cloner = new VarCloner();
+        }
+        return $this->cloner;
     }
 }


### PR DESCRIPTION
This improves #402 as follows:

- Only dump object internals if a custom caster exists. This allows integrations with frameworks to define custom casters. E.g. for Laravel we can dump the attributes of an Eloquent model.
- Don't dump verbose information (e.g. exception stack traces).
