### PR TITLE
Pass Inspector into data table callbacks

### DIFF
--- a/examples/example.php
+++ b/examples/example.php
@@ -36,6 +36,17 @@ $handler->addDataTable('Ice-cream I like', array(
     'Vanilla' => 'ew',
 ));
 
+$handler->addDataTableCallback('Details', function(\Whoops\Exception\Inspector $inspector) {
+    $data = array();
+    $exception = $inspector->getException();
+    if ($exception instanceof SomeSpecificException) {
+        $data['Important exception data'] = $exception->getSomeSpecificData();
+    }
+    $data['Exception class'] = get_class($exception);
+    $data['Exception code'] = $exception->getCode();
+    return $data;
+});
+
 $run->pushHandler($handler);
 
 // Example: tag all frames inside a function with their function name

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -180,8 +180,8 @@ class PrettyPageHandler extends Handler
 
         // Add extra entries list of data tables:
         // @todo: Consolidate addDataTable and addDataTableCallback
-        $extraTables = array_map(function ($table) {
-            return $table instanceof \Closure ? $table() : $table;
+        $extraTables = array_map(function ($table) use ($inspector) {
+            return $table instanceof \Closure ? $table($inspector) : $table;
         }, $this->getDataTables());
         $vars["tables"] = array_merge($extraTables, $vars["tables"]);
 
@@ -223,9 +223,9 @@ class PrettyPageHandler extends Handler
             throw new InvalidArgumentException('Expecting callback argument to be callable');
         }
 
-        $this->extraTables[$label] = function () use ($callback) {
+        $this->extraTables[$label] = function (\Whoops\Exception\Inspector $inspector = null) use ($callback) {
             try {
-                $result = call_user_func($callback);
+                $result = call_user_func($callback, $inspector);
 
                 // Only return the result if it can be iterated over by foreach().
                 return is_array($result) || $result instanceof \Traversable ? $result : array();


### PR DESCRIPTION
It's proposal, backwards compatible.
I've added ability to use Inpector in data table callbacks.
It can be useful when exception messages are not very helpfull and exception contains important data: like raw response info in [Aws](https://github.com/aws/aws-sdk-php/blob/master/src/Exception/AwsException.php), [Elastica](https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Exception/ResponseException.php)
