### PR TITLE
Make code-block use tab size of 4 instead of browser default of 8

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -211,6 +211,9 @@ header {
       box-shadow: 0 3px 0 rgba(0, 0, 0, .05),
                   0 10px 30px rgba(0, 0, 0, .05),
                   inset 0 0 1px 0 rgba(255, 255, 255, .07);
+      -moz-tab-size: 4;
+      -o-tab-size: 4;
+      tab-size: 4;
     }
 
     .linenums {


### PR DESCRIPTION
Many browsers use a default tab width of 8.  This change will reduce it to 4, which I think is more common for code indentation.