### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/tests/Whoops/Handler/CallbackHandlerTest.php
+++ b/tests/Whoops/Handler/CallbackHandlerTest.php
@@ -3,7 +3,6 @@
 namespace Whoops\Handler;
 
 use Whoops\TestCase;
-use Whoops\Handler\CallbackHandler;
 
 class CallbackHandlerTest extends TestCase
 {


### PR DESCRIPTION
This PR

* [x] removes an unused import

💁 Ran

```
$ composer global require friendsofphp/php-cs-fixer:2.0.0-alpha
$ php-cs-fixer fix --using-cache=no --rules=no_unused_imports
```