### PR TITLE
Fix: Use short array syntax

### DIFF
--- a/examples/example.php
+++ b/examples/example.php
@@ -29,12 +29,12 @@ $run     = new Run();
 $handler = new PrettyPageHandler();
 
 // Add a custom table to the layout:
-$handler->addDataTable('Ice-cream I like', array(
+$handler->addDataTable('Ice-cream I like', [
     'Chocolate' => 'yes',
     'Coffee & chocolate' => 'a lot',
     'Strawberry & chocolate' => 'it\'s alright',
     'Vanilla' => 'ew',
-));
+]);
 
 $run->pushHandler($handler);
 

--- a/src/Whoops/Exception/Formatter.php
+++ b/src/Whoops/Exception/Formatter.php
@@ -19,26 +19,26 @@ class Formatter
     public static function formatExceptionAsDataArray(Inspector $inspector, $shouldAddTrace)
     {
         $exception = $inspector->getException();
-        $response = array(
+        $response = [
             'type'    => get_class($exception),
             'message' => $exception->getMessage(),
             'file'    => $exception->getFile(),
             'line'    => $exception->getLine(),
-        );
+        ];
 
         if ($shouldAddTrace) {
             $frames    = $inspector->getFrames();
-            $frameData = array();
+            $frameData = [];
 
             foreach ($frames as $frame) {
                 /** @var Frame $frame */
-                $frameData[] = array(
+                $frameData[] = [
                     'file'     => $frame->getFile(),
                     'line'     => $frame->getLine(),
                     'function' => $frame->getFunction(),
                     'class'    => $frame->getClass(),
                     'args'     => $frame->getArgs(),
-                );
+                ];
             }
 
             $response['trace'] = $frameData;

--- a/src/Whoops/Exception/Frame.php
+++ b/src/Whoops/Exception/Frame.php
@@ -24,7 +24,7 @@ class Frame implements Serializable
     /**
      * @var array[]
      */
-    protected $comments = array();
+    protected $comments = [];
 
     /**
      * @param array[]
@@ -94,7 +94,7 @@ class Frame implements Serializable
      */
     public function getArgs()
     {
-        return isset($this->frame['args']) ? (array) $this->frame['args'] : array();
+        return isset($this->frame['args']) ? (array) $this->frame['args'] : [];
     }
 
     /**
@@ -136,10 +136,10 @@ class Frame implements Serializable
      */
     public function addComment($comment, $context = 'global')
     {
-        $this->comments[] = array(
+        $this->comments[] = [
             'comment' => $comment,
             'context' => $context,
-        );
+        ];
     }
 
     /**

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -102,7 +102,7 @@ class Inspector
                     $file = '[internal]';
                     $line = 0;
                     
-                    $next_frame = !empty($frames[$k + 1]) ? $frames[$k + 1] : array();
+                    $next_frame = !empty($frames[$k + 1]) ? $frames[$k + 1] : [];
                     
                     if ($this->isValidNextFrame($next_frame)) {
                         $file = $next_frame['file'];
@@ -174,7 +174,7 @@ class Inspector
         }
 
         if (!extension_loaded('xdebug') || !xdebug_is_enabled()) {
-            return array();
+            return [];
         }
 
         // Use xdebug to get the full stack trace and remove the shutdown handler stack trace
@@ -193,14 +193,14 @@ class Inspector
      */
     protected function getFrameFromException($exception)
     {
-        return array(
+        return [
             'file'  => $exception->getFile(),
             'line'  => $exception->getLine(),
             'class' => get_class($exception),
-            'args'  => array(
+            'args'  => [
                 $exception->getMessage(),
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -211,12 +211,12 @@ class Inspector
      */
     protected function getFrameFromError(ErrorException $exception)
     {
-        return array(
+        return [
             'file'  => $exception->getFile(),
             'line'  => $exception->getLine(),
             'class' => null,
-            'args'  => array(),
-        );
+            'args'  => [],
+        ];
     }
     
     /**

--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -39,12 +39,12 @@ class JsonResponseHandler extends Handler
      */
     public function handle()
     {
-        $response = array(
+        $response = [
             'error' => Formatter::formatExceptionAsDataArray(
                 $this->getInspector(),
                 $this->addTraceToOutput()
             ),
-        );
+        ];
 
         if (\Whoops\Util\Misc::canSendHeaders()) {
             header('Content-Type: application/json');

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -23,14 +23,14 @@ class PrettyPageHandler extends Handler
      *
      * @var array
      */
-    private $searchPaths = array();
+    private $searchPaths = [];
 
     /**
      * Fast lookup cache for known resource locations.
      *
      * @var array
      */
-    private $resourceCache = array();
+    private $resourceCache = [];
 
     /**
      * The name of the custom css file.
@@ -42,7 +42,7 @@ class PrettyPageHandler extends Handler
     /**
      * @var array[]
      */
-    private $extraTables = array();
+    private $extraTables = [];
 
     /**
      * @var bool
@@ -70,13 +70,13 @@ class PrettyPageHandler extends Handler
      * A list of known editor strings
      * @var array
      */
-    protected $editors = array(
+    protected $editors = [
         "sublime"  => "subl://open?url=file://%file&line=%line",
         "textmate" => "txmt://open?url=file://%file&line=%line",
         "emacs"    => "emacs://open?url=file://%file&line=%line",
         "macvim"   => "mvim://open/?url=file://%file&line=%line",
         "phpstorm" => "phpstorm://open?file=%file&line=%line",
-    );
+    ];
 
     /**
      * Constructor.
@@ -86,7 +86,7 @@ class PrettyPageHandler extends Handler
         if (ini_get('xdebug.file_link_format') || extension_loaded('xdebug')) {
             // Register editor using xdebug's file_link_format option.
             $this->editors['xdebug'] = function ($file, $line) {
-                return str_replace(array('%f', '%l'), array($file, $line), ini_get('xdebug.file_link_format'));
+                return str_replace(['%f', '%l'], [$file, $line], ini_get('xdebug.file_link_format'));
             };
         }
 
@@ -159,7 +159,7 @@ class PrettyPageHandler extends Handler
         }
 
         // List of variables that will be passed to the layout template.
-        $vars = array(
+        $vars = [
             "page_title" => $this->getPageTitle(),
 
             // @todo: Asset compiler
@@ -184,16 +184,16 @@ class PrettyPageHandler extends Handler
             "handler"        => $this,
             "handlers"       => $this->getRun()->getHandlers(),
 
-            "tables"      => array(
+            "tables"      => [
                 "GET Data"              => $_GET,
                 "POST Data"             => $_POST,
                 "Files"                 => $_FILES,
                 "Cookies"               => $_COOKIE,
-                "Session"               => isset($_SESSION) ? $_SESSION :  array(),
+                "Session"               => isset($_SESSION) ? $_SESSION :  [],
                 "Server/Request Data"   => $_SERVER,
                 "Environment Variables" => $_ENV,
-            ),
-        );
+            ],
+        ];
 
         if (isset($customCssFile)) {
             $vars["stylesheet"] .= file_get_contents($customCssFile);
@@ -249,10 +249,10 @@ class PrettyPageHandler extends Handler
                 $result = call_user_func($callback);
 
                 // Only return the result if it can be iterated over by foreach().
-                return is_array($result) || $result instanceof \Traversable ? $result : array();
+                return is_array($result) || $result instanceof \Traversable ? $result : [];
             } catch (\Exception $e) {
                 // Don't allow failure to break the rendering of the original exception.
-                return array();
+                return [];
             }
         };
     }
@@ -268,7 +268,7 @@ class PrettyPageHandler extends Handler
     {
         if ($label !== null) {
             return isset($this->extraTables[$label]) ?
-                   $this->extraTables[$label] : array();
+                   $this->extraTables[$label] : [];
         }
 
         return $this->extraTables;
@@ -411,10 +411,10 @@ class PrettyPageHandler extends Handler
         }
         else if(is_string($this->editor) && isset($this->editors[$this->editor]) && !is_callable($this->editors[$this->editor]))
         {
-           return array(
+           return [
                 'ajax' => false,
                 'url' => $this->editors[$this->editor],
-            );
+            ];
         }
         else if(is_callable($this->editor) || (isset($this->editors[$this->editor]) && is_callable($this->editors[$this->editor])))
         {
@@ -427,10 +427,10 @@ class PrettyPageHandler extends Handler
                 $callback = call_user_func($this->editors[$this->editor], $filePath, $line);
             }
 
-            return array(
+            return [
                 'ajax' => isset($callback['ajax']) ? $callback['ajax'] : false,
                 'url' => (is_array($callback) ? $callback['url'] : $callback),
-            );
+            ];
         }
 
         return false;

--- a/src/Whoops/Handler/XmlResponseHandler.php
+++ b/src/Whoops/Handler/XmlResponseHandler.php
@@ -40,12 +40,12 @@ class XmlResponseHandler extends Handler
      */
     public function handle()
     {
-        $response = array(
+        $response = [
             'error' => Formatter::formatExceptionAsDataArray(
                 $this->getInspector(),
                 $this->addTraceToOutput()
             ),
-        );
+        ];
 
         echo $this->toXml($response);
 

--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -29,9 +29,9 @@ final class Run implements RunInterface
     /**
      * @var HandlerInterface[]
      */
-    private $handlerStack = array();
+    private $handlerStack = [];
 
-    private $silencedPatterns = array();
+    private $silencedPatterns = [];
 
     private $system;
 
@@ -91,7 +91,7 @@ final class Run implements RunInterface
      */
     public function clearHandlers()
     {
-        $this->handlerStack = array();
+        $this->handlerStack = [];
         return $this;
     }
 
@@ -118,9 +118,9 @@ final class Run implements RunInterface
             class_exists("\\Whoops\\Exception\\Frame");
             class_exists("\\Whoops\\Exception\\Inspector");
 
-            $this->system->setErrorHandler(array($this, self::ERROR_HANDLER));
-            $this->system->setExceptionHandler(array($this, self::EXCEPTION_HANDLER));
-            $this->system->registerShutdownFunction(array($this, self::SHUTDOWN_HANDLER));
+            $this->system->setErrorHandler([$this, self::ERROR_HANDLER]);
+            $this->system->setExceptionHandler([$this, self::EXCEPTION_HANDLER]);
+            $this->system->registerShutdownFunction([$this, self::SHUTDOWN_HANDLER]);
 
             $this->isRegistered = true;
         }
@@ -170,10 +170,10 @@ final class Run implements RunInterface
             $this->silencedPatterns,
             array_map(
                 function ($pattern) use ($levels) {
-                    return array(
+                    return [
                         "pattern" => $pattern,
                         "levels" => $levels,
-                    );
+                    ];
                 },
                 (array) $patterns
             )
@@ -259,7 +259,7 @@ final class Run implements RunInterface
             // and removing it would be possibly breaking for users.
             $handlerResponse = $handler->handle($exception);
 
-            if (in_array($handlerResponse, array(Handler::LAST_HANDLER, Handler::QUIT))) {
+            if (in_array($handlerResponse, [Handler::LAST_HANDLER, Handler::QUIT])) {
                 // The Handler has handled the exception in some way, and
                 // wishes to quit execution (Handler::QUIT), or skip any
                 // other handlers (Handler::LAST_HANDLER). If $this->allowQuit

--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -21,7 +21,7 @@ class TemplateHelper
      * An array of variables to be passed to all templates
      * @var array
      */
-    private $variables = array();
+    private $variables = [];
 
     /**
      * @var HtmlDumper
@@ -86,7 +86,7 @@ class TemplateHelper
             // re-use the same var-dumper instance, so it won't re-render the global styles/scripts on each dump.
             $this->htmlDumper = new HtmlDumper($this->htmlDumperOutput);
 
-            $styles = array(
+            $styles = [
                 'default' => 'color:#FFFFFF; line-height:normal; font:12px "Inconsolata", "Fira Mono", "Source Code Pro", Monaco, Consolas, "Lucida Console", monospace !important; word-wrap: break-word; white-space: pre-wrap; position:relative; z-index:99999; word-break: normal',
                 'num' => 'color:#BCD42A',
                 'const' => 'color: #4bb1b1;',
@@ -99,7 +99,7 @@ class TemplateHelper
                 'meta' => 'color:#FFFFFF',
                 'key' => 'color:#BCD42A',
                 'index' => 'color:#ef7c61',
-            );
+            ];
             $this->htmlDumper->setStyles($styles);
         }
 

--- a/tests/Whoops/Exception/FrameCollectionTest.php
+++ b/tests/Whoops/Exception/FrameCollectionTest.php
@@ -23,13 +23,13 @@ class FrameCollectionTest extends TestCase
     public function getFrameData()
     {
         $id = ++$this->frameIdCounter;
-        return array(
+        return [
             'file'     => __DIR__ . '/../../fixtures/frame.lines-test.php',
             'line'     => $id,
             'function' => 'test-' . $id,
             'class'    => 'MyClass',
-            'args'     => array(true, 'hello'),
-        );
+            'args'     => [true, 'hello'],
+        ];
     }
 
     /**
@@ -203,15 +203,15 @@ class FrameCollectionTest extends TestCase
     {
         $commonFrameTail = $this->getFrameDataList(3);
 
-        $diffFrame = array('line' => $this->frameIdCounter) + $this->getFrameData();
+        $diffFrame = ['line' => $this->frameIdCounter] + $this->getFrameData();
 
-        $frameCollection1 = new FrameCollection(array_merge(array(
+        $frameCollection1 = new FrameCollection(array_merge([
             $diffFrame,
-        ), $commonFrameTail));
+        ], $commonFrameTail));
 
-        $frameCollection2 = new FrameCollection(array_merge(array(
+        $frameCollection2 = new FrameCollection(array_merge([
             $this->getFrameData(),
-        ), $commonFrameTail));
+        ], $commonFrameTail));
 
         $diff = $frameCollection1->topDiff($frameCollection2);
 

--- a/tests/Whoops/Exception/FrameTest.php
+++ b/tests/Whoops/Exception/FrameTest.php
@@ -15,13 +15,13 @@ class FrameTest extends TestCase
      */
     private function getFrameData()
     {
-        return array(
+        return [
             'file'     => __DIR__ . '/../../fixtures/frame.lines-test.php',
             'line'     => 0,
             'function' => 'test',
             'class'    => 'MyClass',
-            'args'     => array(true, 'hello'),
-        );
+            'args'     => [true, 'hello'],
+        ];
     }
 
     /**
@@ -137,11 +137,11 @@ class FrameTest extends TestCase
     public function testGetComments()
     {
         $frame    = $this->getFrameInstance();
-        $testComments = array(
+        $testComments = [
             'Dang, yo!',
             'Errthangs broken!',
             'Dayumm!',
-        );
+        ];
 
         $frame->addComment($testComments[0]);
         $frame->addComment($testComments[1]);
@@ -163,11 +163,11 @@ class FrameTest extends TestCase
     public function testGetFilteredComments()
     {
         $frame    = $this->getFrameInstance();
-        $testComments = array(
-            array('Dang, yo!', 'test'),
-            array('Errthangs broken!', 'test'),
+        $testComments = [
+            ['Dang, yo!', 'test'],
+            ['Errthangs broken!', 'test'],
             'Dayumm!',
-        );
+        ];
 
         $frame->addComment($testComments[0][0], $testComments[0][1]);
         $frame->addComment($testComments[1][0], $testComments[1][1]);
@@ -211,8 +211,8 @@ class FrameTest extends TestCase
      */
     public function testEquals()
     {
-        $frame1 = $this->getFrameInstance(array('line' => 1, 'file' => 'test-file.php'));
-        $frame2 = $this->getFrameInstance(array('line' => 1, 'file' => 'test-file.php'));
+        $frame1 = $this->getFrameInstance(['line' => 1, 'file' => 'test-file.php']);
+        $frame2 = $this->getFrameInstance(['line' => 1, 'file' => 'test-file.php']);
         $this->assertTrue ($frame1->equals($frame2));
     }
 }

--- a/tests/Whoops/Handler/PrettyPageHandlerTest.php
+++ b/tests/Whoops/Handler/PrettyPageHandlerTest.php
@@ -100,15 +100,15 @@ class PrettyPageHandlerTest extends TestCase
         // should have no tables by default:
         $this->assertEmpty($handler->getDataTables());
 
-        $tableOne = array(
+        $tableOne = [
             'ice' => 'cream',
             'ice-ice' => 'baby',
-        );
+        ];
 
-        $tableTwo = array(
+        $tableTwo = [
             'dolan' => 'pls',
             'time'  => time(),
-        );
+        ];
 
         $handler->addDataTable('table 1', $tableOne);
         $handler->addDataTable('table 2', $tableTwo);
@@ -137,23 +137,23 @@ class PrettyPageHandlerTest extends TestCase
 
         $this->assertEmpty($handler->getDataTables());
         $table1 = function () {
-            return array(
+            return [
                 'hammer' => 'time',
                 'foo'    => 'bar',
-            );
+            ];
         };
-        $expected1 = array('hammer' => 'time', 'foo' => 'bar');
+        $expected1 = ['hammer' => 'time', 'foo' => 'bar'];
 
         $table2 = function () use ($expected1) {
-            return array(
+            return [
                 'another' => 'table',
                 'this'    => $expected1,
-            );
+            ];
         };
-        $expected2 = array('another' => 'table', 'this' => $expected1);
+        $expected2 = ['another' => 'table', 'this' => $expected1];
 
         $table3 = create_function('', 'return array("oh my" => "how times have changed!");');
-        $expected3 = array('oh my' => 'how times have changed!');
+        $expected3 = ['oh my' => 'how times have changed!'];
 
         // Sanity check, make sure expected values really are correct.
         $this->assertSame($expected1, $table1());
@@ -231,10 +231,10 @@ class PrettyPageHandlerTest extends TestCase
         $handler->setEditor(function ($file, $line) {
             $file = rawurlencode($file);
             $line = rawurlencode($line);
-            return array(
+            return [
                 'url' => "http://google.com/search/?q=$file:$line",
                 'ajax' => true,
-            );
+            ];
         });
 
         $this->assertEquals(
@@ -251,10 +251,10 @@ class PrettyPageHandlerTest extends TestCase
         $handler->setEditor(function ($file, $line) {
             $file = rawurlencode($file);
             $line = rawurlencode($line);
-            return array(
+            return [
                 'url' => "http://google.com/search/?q=$file:$line",
                 'ajax' => false,
-            );
+            ];
         });
 
         $this->assertEquals(

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -226,7 +226,7 @@ class RunTest extends TestCase
         // are given the handler, and in the inverse order they were
         // registered.
         $run->handleException($exception);
-        $this->assertEquals((array) $order, array(3, 2, 1));
+        $this->assertEquals((array) $order, [3, 2, 1]);
     }
 
     /**

--- a/tests/Whoops/Util/MiscTest.php
+++ b/tests/Whoops/Util/MiscTest.php
@@ -23,14 +23,14 @@ class MiscTest extends TestCase
 
     public function provideTranslateException()
     {
-        return array(
+        return [
             // When passing an error constant value, ensure the error constant
             // is returned.
-            array('E_USER_WARNING', E_USER_WARNING),
+            ['E_USER_WARNING', E_USER_WARNING],
 
             // When passing a value not equal to an error constant, ensure
             // E_UNKNOWN is returned.
-            array('E_UNKNOWN', 3),
-        );
+            ['E_UNKNOWN', 3],
+        ];
     }
 }

--- a/tests/Whoops/Util/TemplateHelperTest.php
+++ b/tests/Whoops/Util/TemplateHelperTest.php
@@ -80,7 +80,7 @@ class TemplateHelperTest extends TestCase
         $template = __DIR__ . "/../../fixtures/template.php";
 
         ob_start();
-        $this->helper->render($template, array("name" => "B<o>b"));
+        $this->helper->render($template, ["name" => "B<o>b"]);
         $output = ob_get_clean();
 
         $this->assertEquals(
@@ -98,19 +98,19 @@ class TemplateHelperTest extends TestCase
      */
     public function testTemplateVariables()
     {
-        $this->helper->setVariables(array(
+        $this->helper->setVariables([
             "name" => "Whoops",
             "type" => "library",
             "desc" => "php errors for cool kids",
-        ));
+        ]);
 
         $this->helper->setVariable("name", "Whoops!");
         $this->assertEquals($this->helper->getVariable("name"), "Whoops!");
         $this->helper->delVariable("type");
 
-        $this->assertEquals($this->helper->getVariables(), array(
+        $this->assertEquals($this->helper->getVariables(), [
             "name" => "Whoops!",
             "desc" => "php errors for cool kids",
-        ));
+        ]);
     }
 }


### PR DESCRIPTION
This PR

* [x] applies short array syntax

💁 Ran

```
$ composer global require friendsofphp/php-cs-fixer:2.0.0-alpha
$ php-cs-fixer fix --using-cache=no --rules=short_array_syntax
```