### PR TITLE
Remove final flag on the Run class

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -15,7 +15,7 @@ use Whoops\Handler\HandlerInterface;
 use Whoops\Util\Misc;
 use Whoops\Util\SystemFacade;
 
-final class Run implements RunInterface
+class Run implements RunInterface
 {
     private $isRegistered;
     private $allowQuit       = true;


### PR DESCRIPTION
I wanted to extend whoops, and got caught in several places:

1) I implemented the whoops interface, but couldn't use the class as the Handler's expect an implementation of `Run`, not `RunInterface`
2) The run class was final

If there is good reason for this class to be final, the project should atleast type to the interface.
