### PR TITLE
Fix extensibility

### DIFF
--- a/src/Whoops/Handler/Handler.php
+++ b/src/Whoops/Handler/Handler.php
@@ -7,7 +7,7 @@
 namespace Whoops\Handler;
 
 use Whoops\Exception\Inspector;
-use Whoops\Run;
+use Whoops\RunInterface;
 
 /**
  * Abstract implementation of a Handler.
@@ -24,7 +24,7 @@ abstract class Handler implements HandlerInterface
     const QUIT         = 0x30;
 
     /**
-     * @var Run
+     * @var RunInterface
      */
     private $run;
 
@@ -39,15 +39,15 @@ abstract class Handler implements HandlerInterface
     private $exception;
 
     /**
-     * @param Run $run
+     * @param RunInterface $run
      */
-    public function setRun(Run $run)
+    public function setRun(RunInterface $run)
     {
         $this->run = $run;
     }
 
     /**
-     * @return Run
+     * @return RunInterface
      */
     protected function getRun()
     {

--- a/src/Whoops/Handler/HandlerInterface.php
+++ b/src/Whoops/Handler/HandlerInterface.php
@@ -7,7 +7,7 @@
 namespace Whoops\Handler;
 
 use Whoops\Exception\Inspector;
-use Whoops\Run;
+use Whoops\RunInterface;
 
 interface HandlerInterface
 {
@@ -17,10 +17,10 @@ interface HandlerInterface
     public function handle();
 
     /**
-     * @param  Run  $run
+     * @param  RunInterface  $run
      * @return void
      */
-    public function setRun(Run $run);
+    public function setRun(RunInterface $run);
 
     /**
      * @param  \Throwable $exception


### PR DESCRIPTION
Since the `\Whoops\Run` class is final, extending it is a no go, but we should then be able to write our own implementation of it. However, the handlers expect an `\Whoops\Run` instead of `\Whoops\RunInterface`, which stops me from extending Whoops completely.

All that said and done, The RunInterface itself is pretty bloated. Things like `silenceErrorsInPaths` should probably be details of a given implementation, and not in the interface. (For example, my own implementation wouldn't care about that functionality, but I have to implement that function due to the interface contract). I haven't addressed this in this PR, but I could if it we agree.

Edit: This is part of https://github.com/filp/whoops/issues/430