### PR TITLE
Fixes the syntax highlighting issue

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -219,7 +219,7 @@ header {
     .linenums {
       margin: 0;
       margin-left: 10px;
-      max-height: 288px;
+      max-height: 345px;
       overflow: hidden;
     }
 

--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -219,6 +219,8 @@ header {
     .linenums {
       margin: 0;
       margin-left: 10px;
+      max-height: 288px;
+      overflow: hidden;
     }
 
     .frame-comments {

--- a/src/Whoops/Resources/js/whoops.base.js
+++ b/src/Whoops/Resources/js/whoops.base.js
@@ -65,9 +65,9 @@ Zepto(function($) {
 
   });
 
+  // Scroll to the active
   function scrollToLine() {
 
-    var $activeLine     = $frameContainer.find('.frame.active');
     var activeLineNumber = +($activeLine.find('.frame-line').text());
     var id     = /frame\-line\-([\d]*)/.exec($activeLine.attr('id'))[1];
 

--- a/src/Whoops/Resources/js/whoops.base.js
+++ b/src/Whoops/Resources/js/whoops.base.js
@@ -1,4 +1,6 @@
 Zepto(function($) {
+
+
   // a jQuery.getScript() equivalent to asyncronously load javascript files
   // credits to http://stackoverflow.com/a/8812950/1597388
   var getScript = function(src, func) {
@@ -36,6 +38,9 @@ Zepto(function($) {
 
   // Highlight the active for the first frame:
   highlightCurrentLine();
+  setTimeout(function() {
+    scrollToLine();
+  }, 500);
 
   $frameContainer.on('click', '.frame', function() {
     var $this  = $(this);
@@ -54,9 +59,23 @@ Zepto(function($) {
 
       highlightCurrentLine();
 
-      $container.scrollTop(0);
+      scrollToLine();
+
     }
+
   });
+
+  function scrollToLine() {
+
+    var $activeLine     = $frameContainer.find('.frame.active');
+    var activeLineNumber = +($activeLine.find('.frame-line').text());
+    var id     = /frame\-line\-([\d]*)/.exec($activeLine.attr('id'))[1];
+
+    $line = $('#frame-code-' + id + ' .linenums li:nth-child(' + (activeLineNumber-8) + ')');
+    $line[0].scrollIntoView({block: 'end', behavior: 'smooth'});
+    $container.scrollTop(0);
+
+  }
 
   var clipboard = new Clipboard('.clipboard');
   var showTooltip = function(elem, msg) {

--- a/src/Whoops/Resources/js/whoops.base.js
+++ b/src/Whoops/Resources/js/whoops.base.js
@@ -71,7 +71,7 @@ Zepto(function($) {
     var activeLineNumber = +($activeLine.find('.frame-line').text());
     var id     = /frame\-line\-([\d]*)/.exec($activeLine.attr('id'))[1];
 
-    $line = $('#frame-code-' + id + ' .linenums li:nth-child(' + (activeLineNumber-8) + ')');
+    $line = $('#frame-code-' + id + ' .linenums li:nth-child(' + (activeLineNumber-10) + ')');
     $line[0].scrollIntoView({block: 'end', behavior: 'smooth'});
     $container.scrollTop(0);
 

--- a/src/Whoops/Resources/views/frame_code.html.php
+++ b/src/Whoops/Resources/views/frame_code.html.php
@@ -21,7 +21,8 @@
           if ($line !== null):
 
           // the $line is 1-indexed, we nab -1 where needed to account for this
-          $range = $frame->getFileLines($line - 10, 20);
+          //$range = $frame->getFileLines($line - 10, 20);
+          $range = $frame->getFileLines(0);
 
           // getFileLines can return null if there is no source code
           if ($range):
@@ -30,20 +31,21 @@
             $code  = join("\n", $range);
         ?>
             <style>
-             #frame-code-0 .linenums li:nth-child(<?= $line-$start ?>) {
+             #frame-code-<?=$i?> .linenums li:nth-child(<?= $line-1 ?>) {
                  background-color: rgba(255, 100, 100, .07); 
                  padding: 2px;
               }
-             #frame-code-0 .linenums li:nth-child(<?= $line-$start+1 ?>) {
+             #frame-code-<?=$i?> .linenums li:nth-child(<?= $line ?>) {
                  background-color: rgba(255, 100, 100, .17); 
                  padding: 2px;
               }
-             #frame-code-0 .linenums li:nth-child(<?= $line-$start+2 ?>) {
+             #frame-code-<?=$i?> .linenums li:nth-child(<?= $line+1 ?>) {
                  background-color: rgba(255, 100, 100, .07); 
                  padding: 2px;
               }
             </style>
-            <pre class="code-block prettyprint linenums:<?php echo $start ?>"><?php echo $tpl->escape($code) ?></pre>
+            <pre id="frame-code-linenums-<?=$i?>" class="code-block prettyprint linenums:<?php echo $start ?>"><?php echo $tpl->escape($code) ?></pre>
+
           <?php endif ?>
         <?php endif ?>
 


### PR DESCRIPTION
This addresses #435, #214, #426, and #385 

From
![image](https://cloud.githubusercontent.com/assets/967369/17460159/720c2c12-5c0e-11e6-9c5d-676c4e267fb5.png)

To

![image](https://cloud.githubusercontent.com/assets/967369/17460177/fc38dc64-5c0e-11e6-90ce-6282725d0fce.png)


What it does is allow the prettifier to highlight the entire file, then i set a maximum height on the containing div and scroll to the line of code, this could also allow the functionality to browse the entire file if we wanted, but would show scrollbars on windows machines.