### PR TITLE
setJsonApi() in JsonResponseHandler to allow format compliant to json:api spec

### DIFF
--- a/examples/example-ajax-only.php
+++ b/examples/example-ajax-only.php
@@ -37,6 +37,11 @@ if (\Whoops\Util\Misc::isAjaxRequest()) {
     // You can also tell JsonResponseHandler to give you a full stack trace:
     // $jsonHandler->addTraceToOutput(true);
 
+    // You can also return a result compliant to the json:api spec
+    // re: http://jsonapi.org/examples/#error-objects
+    // tl;dr: error[] becomes errors[[]]
+   $jsonHandler->setJsonApi(true);
+
     // And push it into the stack:
     $run->pushHandler($jsonHandler);
 }

--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -55,7 +55,6 @@ class JsonResponseHandler extends Handler
      */
     public function handle()
     {
-
       if ($this->jsonApi === true) {
         $response = [
           'errors' => [

--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -21,6 +21,22 @@ class JsonResponseHandler extends Handler
     private $returnFrames = false;
 
     /**
+     * @var bool
+     */
+    private $jsonApi = false;
+
+    /**
+     * Returns errors[[]] instead of error[] to be in compliance with the json:api spec
+     * @param bool Default is false
+     * @return $this
+     */
+    public function setJsonApi($jsonApi=false)
+    {
+        $this->jsonApi = (bool) $jsonApi;
+        return $this;
+    }
+
+    /**
      * @param  bool|null  $returnFrames
      * @return bool|$this
      */
@@ -39,12 +55,24 @@ class JsonResponseHandler extends Handler
      */
     public function handle()
     {
+
+      if ($this->jsonApi === true) {
+        $response = [
+          'errors' => [
+            Formatter::formatExceptionAsDataArray(
+                  $this->getInspector(),
+                  $this->addTraceToOutput()
+            ),
+          ]
+        ];
+      } else {
         $response = [
             'error' => Formatter::formatExceptionAsDataArray(
                 $this->getInspector(),
                 $this->addTraceToOutput()
             ),
         ];
+      }
 
         if (\Whoops\Util\Misc::canSendHeaders()) {
             header('Content-Type: application/json');

--- a/tests/Whoops/Handler/JsonResponseHandlerTest.php
+++ b/tests/Whoops/Handler/JsonResponseHandlerTest.php
@@ -33,7 +33,6 @@ class JsonResponseHandlerTest extends TestCase
      */
     private function getJsonResponseFromHandler($withTrace = false, $jsonApi = false)
     {
-
         $handler = $this->getHandler();
         $handler->setJsonApi($jsonApi);
         $handler->addTraceToOutput($withTrace);
@@ -59,7 +58,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsWithoutFrames()
     {
-        $json = $this->getJsonResponseFromHandler(false,false);
+        $json = $this->getJsonResponseFromHandler($withTrace = false,$jsonApi = false);
 
         // Check that the response has the expected keys:
         $this->assertArrayHasKey('error', $json);
@@ -82,7 +81,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsWithFrames()
     {
-        $json = $this->getJsonResponseFromHandler(true,false);
+        $json = $this->getJsonResponseFromHandler($withTrace = true,$jsonApi = false);
 
         // Check that the trace is returned:
         $this->assertArrayHasKey('trace', $json['error']);
@@ -102,7 +101,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsJsonApi()
     {
-        $json = $this->getJsonResponseFromHandler(false,true);
+        $json = $this->getJsonResponseFromHandler($withTrace = false,$jsonApi = true);
 
         // Check that the response has the expected keys:
         $this->assertArrayHasKey('errors', $json);

--- a/tests/Whoops/Handler/JsonResponseHandlerTest.php
+++ b/tests/Whoops/Handler/JsonResponseHandlerTest.php
@@ -31,9 +31,11 @@ class JsonResponseHandlerTest extends TestCase
      * @param  bool  $withTrace
      * @return array
      */
-    private function getJsonResponseFromHandler($withTrace = false)
+    private function getJsonResponseFromHandler($withTrace = false, $jsonApi = false)
     {
+
         $handler = $this->getHandler();
+        $handler->setJsonApi($jsonApi);
         $handler->addTraceToOutput($withTrace);
 
         $run = $this->getRunInstance();
@@ -57,7 +59,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsWithoutFrames()
     {
-        $json = $this->getJsonResponseFromHandler($withTrace = false);
+        $json = $this->getJsonResponseFromHandler($withTrace = false, $jsonApi = false);
 
         // Check that the response has the expected keys:
         $this->assertArrayHasKey('error', $json);
@@ -80,7 +82,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsWithFrames()
     {
-        $json = $this->getJsonResponseFromHandler($withTrace = true);
+        $json = $this->getJsonResponseFromHandler($withTrace = true, $jsonApi = false);
 
         // Check that the trace is returned:
         $this->assertArrayHasKey('trace', $json['error']);
@@ -93,4 +95,29 @@ class JsonResponseHandlerTest extends TestCase
         $this->assertArrayHasKey('class', $traceFrame);
         $this->assertArrayHasKey('args', $traceFrame);
     }
+
+    /**
+     * @covers Whoops\Handler\JsonResponseHandler::addTraceToOutput
+     * @covers Whoops\Handler\JsonResponseHandler::handle
+     */
+    public function testReturnsJsonApi()
+    {
+        $json = $this->getJsonResponseFromHandler($withTrace = false, $jsonApi = true);
+
+        // Check that the response has the expected keys:
+        $this->assertArrayHasKey('errors', $json);
+        $this->assertArrayHasKey('type', $json['errors'][0]);
+        $this->assertArrayHasKey('file', $json['errors'][0]);
+        $this->assertArrayHasKey('line', $json['errors'][0]);
+
+        // Check the field values:
+        $this->assertEquals($json['errors'][0]['file'], __FILE__);
+        $this->assertEquals($json['errors'][0]['message'], 'test message');
+        $this->assertEquals($json['errors'][0]['type'], get_class($this->getException()));
+
+        // Check that the trace is NOT returned:
+        $this->assertArrayNotHasKey('trace', $json['errors']);
+    }
+
+ 
 }

--- a/tests/Whoops/Handler/JsonResponseHandlerTest.php
+++ b/tests/Whoops/Handler/JsonResponseHandlerTest.php
@@ -59,7 +59,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsWithoutFrames()
     {
-        $json = $this->getJsonResponseFromHandler($withTrace = false, $jsonApi = false);
+        $json = $this->getJsonResponseFromHandler(false,false);
 
         // Check that the response has the expected keys:
         $this->assertArrayHasKey('error', $json);
@@ -82,7 +82,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsWithFrames()
     {
-        $json = $this->getJsonResponseFromHandler($withTrace = true, $jsonApi = false);
+        $json = $this->getJsonResponseFromHandler(true,false);
 
         // Check that the trace is returned:
         $this->assertArrayHasKey('trace', $json['error']);
@@ -102,7 +102,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsJsonApi()
     {
-        $json = $this->getJsonResponseFromHandler($withTrace = false, $jsonApi = true);
+        $json = $this->getJsonResponseFromHandler(false,true);
 
         // Check that the response has the expected keys:
         $this->assertArrayHasKey('errors', $json);


### PR DESCRIPTION
Addresses issue #442 , call the method`setJsonApi()` of the `JsonResponseHandler` passing in `true` and receive a result compliant to the [json:api specification](http://jsonapi.org/examples/#error-objects)

```json
{
  "errors": [
    {
      "type": "ErrorException",
      "message": "Undefined variable: bob",
      "file": "/Users/k/basal/app/Api/UserController.php",
      "line": 28
    }
  ]
}
```