### PR TITLE
Add IntelliJ IDEA support

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -76,6 +76,7 @@ class PrettyPageHandler extends Handler
         "emacs"    => "emacs://open?url=file://%file&line=%line",
         "macvim"   => "mvim://open/?url=file://%file&line=%line",
         "phpstorm" => "phpstorm://open?file=%file&line=%line",
+        "idea"     => "idea://open?file=%file&line=%line",
     ];
 
     /**


### PR DESCRIPTION
Some of us use IntelliJ IDEA with the PHP plugin instead of PhpStorm.

I'm aware that setEditor() takes a callable, but using a known editor makes it much easier to configure. A twelve-factor app can simply check the environment for `WHOOPS_EDITOR=idea` and pass that value directly into PrettyPageHandler instead of adding a bunch of logic to convert it into a callable.