### PR TITLE
Add silencedPatterns getter

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -181,6 +181,17 @@ final class Run implements RunInterface
         return $this;
     }
 
+
+    /**
+     * Returns an array with silent errors in path configuration
+     *
+     * @return array
+     */
+    public function getSilenceErrorsInPaths()
+    {
+        return $this->silencedPatterns;
+    }
+
     /*
      * Should Whoops send HTTP error code to the browser if possible?
      * Whoops will by default send HTTP code 500, but you may wish to


### PR DESCRIPTION
For example if we want to change logic of the `Whoops\Run::handleError` we can extend `SystemFacade` and rewrite method `setErrorHandler`. But unfortunately we can`t filter errors inside our custom error handler.

