### PR TITLE
Whoos v1 is not php7 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": "^5.3.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"


### PR DESCRIPTION
In v1 php7 doesnt really work because of used Exception type (which doesnt work with Error types)