### PR TITLE
added psr/log to required dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": "^5.5.9 || ^7.0"
+        "php": "^5.5.9 || ^7.0",
+        "psr/log": "^1.0.1"        
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.0",


### PR DESCRIPTION
Requirement inspired by Monolog. Technically we have a `use` Statement which requires this lib. the remaining phpdoc typehints would work without the lib, but still this seems to be the clean way.

Closes #483.