### PR TITLE
Don't hide horizontal panel overflow

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -13,7 +13,6 @@ body {
   }
 
 .panel {
-    overflow-x: hidden;
     overflow-y: scroll;
     height: 100%;
     position: fixed;


### PR DESCRIPTION
We need scrollbar because otherwise when DataTable row is too long it's cut and not visible