### PR TITLE
Feature: add discovering public properties from Exception

### DIFF
--- a/docs/API Documentation.md
+++ b/docs/API Documentation.md
@@ -323,11 +323,10 @@ The `JSON` body has the following format:
 JsonResponseHandler::addTraceToOutput(bool $yes = null)
  #=> bool
  
- // Should public properties from the Exception be added to the
- // JSON payload body?
- JsonResponseHandler::discoverPublicProperties(bool $yes = null)
+// Should public properties from the Exception be added to the
+// JSON payload body?
+JsonResponseHandler::discoverPublicProperties(bool $yes = null)
  #=> boll
- 
 
 JsonResponseHandler::handle()
  #=> int | null

--- a/docs/API Documentation.md
+++ b/docs/API Documentation.md
@@ -299,7 +299,17 @@ The `JSON` body has the following format:
           "class": "MyApplication\DoerOfThings",
           "args": [ true, 10, "yay method arguments" ] },
         # ... more frames here ...
-     ]
+     ],
+     
+     # if JsonResponseHandler::discoverPublicProperties(true):
+     "properties": {
+        "foo": "bar",
+        "things": [
+           "meat",
+           "tomato",
+           "salad"
+        ]
+     }
   }
 }
 ```
@@ -312,6 +322,12 @@ The `JSON` body has the following format:
 // JSON payload body?
 JsonResponseHandler::addTraceToOutput(bool $yes = null)
  #=> bool
+ 
+ // Should public properties from the Exception be added to the
+ // JSON payload body?
+ JsonResponseHandler::discoverPublicProperties(bool $yes = null)
+ #=> boll
+ 
 
 JsonResponseHandler::handle()
  #=> int | null

--- a/src/Whoops/Exception/Formatter.php
+++ b/src/Whoops/Exception/Formatter.php
@@ -14,10 +14,14 @@ class Formatter
      * for further convertion to other languages
      * @param  Inspector $inspector
      * @param  bool      $shouldAddTrace
+     * @param  bool      $shouldDiscoverPublicProperties
      * @return array
      */
-    public static function formatExceptionAsDataArray(Inspector $inspector, $shouldAddTrace)
-    {
+    public static function formatExceptionAsDataArray(
+        Inspector $inspector,
+        $shouldAddTrace,
+        $shouldDiscoverPublicProperties
+    ) {
         $exception = $inspector->getException();
         $response = [
             'type'    => get_class($exception),
@@ -42,6 +46,10 @@ class Formatter
             }
 
             $response['trace'] = $frameData;
+        }
+
+        if ($shouldDiscoverPublicProperties) {
+            $response['properties'] = $inspector->getPublicProperties();
         }
 
         return $response;

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -274,4 +274,13 @@ class Inspector
 
         return true;
     }
+
+    /**
+     * Returns the public properties from an exception.
+     * @return array
+     */
+    public function getPublicProperties()
+    {
+        return get_object_vars($this->exception);
+    }
 }

--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -26,6 +26,11 @@ class JsonResponseHandler extends Handler
     private $jsonApi = false;
 
     /**
+     * @var bool
+     */
+    private $discoverPublicProperties = false;
+
+    /**
      * Returns errors[[]] instead of error[] to be in compliance with the json:api spec
      * @param bool $jsonApi Default is false
      * @return $this
@@ -51,6 +56,20 @@ class JsonResponseHandler extends Handler
     }
 
     /**
+     * @param  bool|null  $discoverPublicProperties
+     * @return bool|$this
+     */
+    public function discoverPublicProperties($discoverPublicProperties = null)
+    {
+        if (func_num_args() == 0) {
+            return $this->discoverPublicProperties;
+        }
+
+        $this->discoverPublicProperties = (bool) $discoverPublicProperties;
+        return $this;
+    }
+
+    /**
      * @return int
      */
     public function handle()
@@ -60,7 +79,8 @@ class JsonResponseHandler extends Handler
           'errors' => [
             Formatter::formatExceptionAsDataArray(
                   $this->getInspector(),
-                  $this->addTraceToOutput()
+                  $this->addTraceToOutput(),
+                  $this->discoverPublicProperties()
             ),
           ]
         ];
@@ -68,7 +88,8 @@ class JsonResponseHandler extends Handler
         $response = [
             'error' => Formatter::formatExceptionAsDataArray(
                 $this->getInspector(),
-                $this->addTraceToOutput()
+                $this->addTraceToOutput(),
+                $this->discoverPublicProperties()
             ),
         ];
       }

--- a/src/Whoops/Handler/XmlResponseHandler.php
+++ b/src/Whoops/Handler/XmlResponseHandler.php
@@ -22,6 +22,11 @@ class XmlResponseHandler extends Handler
     private $returnFrames = false;
 
     /**
+     * @var bool
+     */
+    private $discoverPublicProperties = false;
+
+    /**
      * @param  bool|null  $returnFrames
      * @return bool|$this
      */
@@ -36,6 +41,20 @@ class XmlResponseHandler extends Handler
     }
 
     /**
+     * @param  bool|null  $discoverPublicProperties
+     * @return bool|$this
+     */
+    public function discoverPublicProperties($discoverPublicProperties = null)
+    {
+        if (func_num_args() == 0) {
+            return $this->discoverPublicProperties;
+        }
+
+        $this->discoverPublicProperties = (bool) $discoverPublicProperties;
+        return $this;
+    }
+
+    /**
      * @return int
      */
     public function handle()
@@ -43,7 +62,8 @@ class XmlResponseHandler extends Handler
         $response = [
             'error' => Formatter::formatExceptionAsDataArray(
                 $this->getInspector(),
-                $this->addTraceToOutput()
+                $this->addTraceToOutput(),
+                $this->discoverPublicProperties()
             ),
         ];
 


### PR DESCRIPTION
This feature allows you to enable (disabled by default) public properties discovering from an Exception when using  `JsonResponseHandler` or `XmlResponseHandler`.

For example, if you define a custom Exception like this:

```php
class ValidationException extends Exception {
    public $errors = [];

    public function __construct(Validator $validator) {
        $this->errors = $validator->errors()->all();

        parent::__construct('Validation failed.');
    }
}
```

If a `ValidationException` is thrown, the validation errors messages (`$errors` public property) will be displayed if your JSON or XML like that:

```json
{
  "error": {
    "type": "ValidationException",
    "message": "Validation failed.",
    "file": "...",
    "line": 42,
    "properties": {
      "errors": {      // $errors public property
        "title": "The field title is required",
        "body": "The field body is required",
      }
    }
  }
}
```

To enable/disable public properties discovering:
```php
$handler = new JsonResponseHandler();
// or 
$handler = new XmlResponseHandler();

$handler->discoverPublicProperties(true); // disabled by default
```