### PR TITLE
Changed 404-ing repo to a new handler

### DIFF
--- a/docs/Open Files In An Editor.md
+++ b/docs/Open Files In An Editor.md
@@ -19,7 +19,7 @@ The following editors are currently supported by default.
 - `idea`     - IDEA
 - `macvim`   - MacVim
 - `phpstorm` - PhpStorm
-- `sublime`  - Sublime Text 2 and possibly 3 (on OS X you might need [a special handler](https://github.com/dhoulb/subl))
+- `sublime`  - Sublime Text 2 and possibly 3 (on OS X you might need [a special handler](https://github.com/saetia/sublime-url-protocol-mac))
 - `textmate` - Textmate
 - `xdebug`   - xdebug (uses [xdebug.file_link_format](http://xdebug.org/docs/all_settings#file_link_format))
 - `vscode`   - VSCode (ref [Opening VS Code with URLs](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls))


### PR DESCRIPTION
The repo docs pointed to 404ed. New link was provided.