### PR TITLE
Update Open Files In An Editor.md

### DIFF
--- a/docs/Open Files In An Editor.md
+++ b/docs/Open Files In An Editor.md
@@ -18,7 +18,7 @@ The following editors are currently supported by default.
 - `emacs`    - Emacs
 - `idea`     - IDEA
 - `macvim`   - MacVim
-- `phpstorm` - PhpStorm
+- `phpstorm` - PhpStorm (macOS only)
 - `sublime`  - Sublime Text 2 and possibly 3 (on OS X you might need [a special handler](https://github.com/dhoulb/subl))
 - `textmate` - Textmate
 - `xdebug`   - xdebug (uses [xdebug.file_link_format](http://xdebug.org/docs/all_settings#file_link_format))
@@ -46,7 +46,7 @@ $handler->setEditor(
             $file = preg_replace('#' . $from . '#', $to, $file, 1);
         }
 
-        // Intellig platform requires that you send an Ajax request, else the browser will quit the page
+        // IntelliJ platform requires that you send an Ajax request, else the browser will quit the page
         return array(
             'url' => "http://localhost:63342/api/file/?file=$file&line=$line",
             'ajax' => true


### PR DESCRIPTION
Note for `phpstorm` editor because `phpstorm://` is not working on Windows and Linux.
https://youtrack.jetbrains.com/issue/IDEA-65879#comment=27-801082
https://github.com/filp/whoops/issues/409#issuecomment-217416412
At least it didn't work for me on Windows 10 and latest PhpStorm.

Not sure why you use `phpstorm://` for `phpstorm` editor because
```php
[
    "url" => "http://localhost:63342/api/file/{$file}:{$line}",
]
```
is most likely working for all platforms.
