### PR TITLE
Bugfix/stacktrace is missing for haltable exceptions

### DIFF
--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -189,7 +189,7 @@ class Inspector
      *
      * If xdebug is installed
      *
-     * @param  \Throwable $exception
+     * @param  \Throwable $e
      * @return array
      */
     protected function getTrace($e)

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -194,27 +194,16 @@ class Inspector
      */
     protected function getTrace($e)
     {
-        $traces = $e->getTrace();
-
-        // Get trace from xdebug if enabled, failure exceptions only trace to the shutdown handler by default
-        if (!$e instanceof \ErrorException) {
-            return $traces;
-        }
-
-        if (!Misc::isLevelFatal($e->getSeverity())) {
-            return $traces;
-        }
-
-        if (!extension_loaded('xdebug') || !xdebug_is_enabled()) {
-            return [];
-        }
-
         // Use xdebug to get the full stack trace and remove the shutdown handler stack trace
-        $stack = array_reverse(xdebug_get_function_stack());
-        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        $traces = array_diff_key($stack, $trace);
+        if (extension_loaded('xdebug') && xdebug_is_enabled()
+            && $e instanceof \ErrorException && Misc::isLevelFatal($e->getSeverity())) {
+            $stack = array_reverse(xdebug_get_function_stack());
+            $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
-        return $traces;
+            return array_diff_key($stack, $trace);
+        }
+
+        return $e->getTrace();
     }
 
     /**

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -195,8 +195,7 @@ class Inspector
     protected function getTrace($e)
     {
         // Use xdebug to get the full stack trace and remove the shutdown handler stack trace
-        if (extension_loaded('xdebug') && xdebug_is_enabled()
-            && $e instanceof \ErrorException && Misc::isLevelFatal($e->getSeverity())) {
+        if ($this->useXdebugForTrace($e)) {
             $stack = array_reverse(xdebug_get_function_stack());
             $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
@@ -204,6 +203,18 @@ class Inspector
         }
 
         return $e->getTrace();
+    }
+
+    /**
+     * Determine if we should use xdebug for our stack trace
+     *
+     * @param \Throwable $e
+     * @return bool
+     */
+    protected function useXdebugForTrace($e)
+    {
+        return extension_loaded('xdebug') && xdebug_is_enabled()
+            && $e instanceof \ErrorException && Misc::isLevelFatal($e->getSeverity());
     }
 
     /**


### PR DESCRIPTION
I noticed I was missing a stack trace for a FatalThrowableError Exception that should have had one and found it was caused by returning an empty array for the stack trace due to a commit adding ability to get stack trace from xdebug for fatal errors:
https://github.com/filp/whoops/commit/c7ab11811ab4a68d8137793e455984bfc2207073