### PR TITLE
Robots - noindex,nofollow

### DIFF
--- a/src/Whoops/Resources/views/layout.html.php
+++ b/src/Whoops/Resources/views/layout.html.php
@@ -7,6 +7,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="robots" content="noindex,nofollow"/>
     <title><?php echo $tpl->escape($page_title) ?></title>
 
     <style><?php echo $stylesheet ?></style>


### PR DESCRIPTION
People are not turning off debug mode so google search is indexing error pages. 
This can help.