### PR TITLE
Prevent hiding content file and/or arguments

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -228,7 +228,6 @@ header {
     }
 
     .code-block {
-      max-height: 345px;
       overflow: hidden;
       padding: 10px;
       margin: 0;


### PR DESCRIPTION
Fix #529 
limiting height to 345px for .frame-code div only display 23 line.
deleting max-height attributepermit to show all the content
Note that by default:
- code view limite the number of line to 40 $range = $frame->getFileLines($line - 20, 40);
- arguments view always collapse array content

Overview to the problem:

![fix529](https://user-images.githubusercontent.com/1620009/31053454-a8899c7c-a69d-11e7-9726-6b6630d9aa43.png)
