### PR TITLE
Removed type hint from masked function

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -688,7 +688,7 @@ class PrettyPageHandler extends Handler
      * @param $superGlobalName string the name of the superglobal array, e.g. '_GET'
      * @return array $values without sensitive data
      */
-    private function masked(array $superGlobal, $superGlobalName) {
+    private function masked($superGlobal, $superGlobalName) {
         $blacklisted = $this->blacklist[$superGlobalName];
 
         $values = $superGlobal;


### PR DESCRIPTION
This type hint cause an error, when the session contains an object: 

> Fatal error: Uncaught TypeError: Argument 1 passed to Whoops\Handler\PrettyPageHandler::masked() must be of the type array, object given, called in /var/www/html/vendor/filp/whoops/src/Whoops/Handler/PrettyPageHandler.php on line 224 and defined in /var/www/html/vendor/filp/whoops/src/Whoops/Handler/PrettyPageHandler.php on line 691

I tried to write a unit test for this error, but this always produced an error in the `handle` function.
When a additional test is needed, guide me how to execute the `handle` function in a unit test, please .