### PR TITLE
Updated keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "filp/whoops",
     "license": "MIT",
     "description": "php error handling for cool kids",
-    "keywords": ["library", "error", "handling", "exception", "whoops", "zf2"],
+    "keywords": ["library", "error", "handling", "exception", "whoops", "throwable"],
     "homepage": "https://filp.github.io/whoops/",
     "authors": [
         {


### PR DESCRIPTION
In my eyes whoops is framework agnostic, therefore drop zf2 keyword.