### PR TITLE
Support for wildcard blacklist to blacklist a value from all superGlobals

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -70,6 +70,7 @@ class PrettyPageHandler extends Handler
         '_SESSION' => [],
         '_SERVER' => [],
         '_ENV' => [],
+        '*' => [],
     ];
 
     /**
@@ -685,11 +686,11 @@ class PrettyPageHandler extends Handler
      * @param $superGlobalName string the name of the superglobal array, e.g. '_GET'
      * @return array
      */
-    private function getBlacklistForSuperGlobal($superGlobalName)
+    public function getBlacklistForSuperGlobal($superGlobalName)
     {
         return array_unique(array_merge(
-            (array) $this->blacklist['*'],
-            (array) $this->blacklist[$superGlobalName]
+            $this->blacklist['*'],
+            $this->blacklist[$superGlobalName]
         ));
     }
 

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -680,6 +680,20 @@ class PrettyPageHandler extends Handler
     }
 
     /**
+     * Get the blacklisted values for the given superGlobal
+     *
+     * @param $superGlobalName string the name of the superglobal array, e.g. '_GET'
+     * @return array
+     */
+    private function getBlacklistForSuperGlobal($superGlobalName)
+    {
+        return array_unique(array_merge(
+            (array) $this->blacklist['*'],
+            (array) $this->blacklist[$superGlobalName]
+        ));
+    }
+
+    /**
      * Checks all values within the given superGlobal array.
      * Blacklisted values will be replaced by a equal length string cointaining only '*' characters.
      *
@@ -691,7 +705,7 @@ class PrettyPageHandler extends Handler
      */
     private function masked(array $superGlobal, $superGlobalName)
     {
-        $blacklisted = $this->blacklist[$superGlobalName];
+        $blacklisted = $this->getBlacklistForSuperGlobal($superGlobalName);
 
         $values = $superGlobal;
         foreach ($blacklisted as $key) {

--- a/tests/Whoops/Handler/PrettyPageHandlerTest.php
+++ b/tests/Whoops/Handler/PrettyPageHandlerTest.php
@@ -339,4 +339,27 @@ class PrettyPageHandlerTest extends TestCase
 
         ini_set('xdebug.file_link_format', $originalValue);
     }
+
+    /**
+     * @covers PrettyPageHandler::blacklist
+     * @covers PrettyPageHandler::getBlacklistForSuperGlobal
+     */
+    public function testGetBlacklistForSuperGlobal()
+    {
+        $handler = $this->getHandler();
+        $handler->blacklist('_ENV', 'DB_PASSWORD');
+        $handler->blacklist('_ENV', 'API_KEY');
+        $handler->blacklist('*', 'API_KEY');
+        $handler->blacklist('*', 'MAIL_PASSWORD');
+
+        $this->assertEquals(
+            ['API_KEY', 'MAIL_PASSWORD', 'DB_PASSWORD'],
+            $handler->getBlacklistForSuperGlobal('_ENV')
+        );
+
+        $this->assertEquals(
+            ['API_KEY', 'MAIL_PASSWORD'],
+            $handler->getBlacklistForSuperGlobal('_POST')
+        );
+    }
 }


### PR DESCRIPTION
I had a lot of repetition between my `_SERVER` and `_ENV` blacklist values so I figured it would be nice if there was support for the `*` wildcard. Any key blacklisted with the super global name of `*` will be blacklisted for all super globals.
