### PR TITLE
Replace the file root path if it's different. 

### DIFF
--- a/src/Whoops/Resources/views/frame_code.html.php
+++ b/src/Whoops/Resources/views/frame_code.html.php
@@ -6,7 +6,7 @@
     <?php $line = $frame->getLine(); ?>
       <div class="frame-code <?php echo ($i == 0 ) ? 'active' : '' ?>" id="frame-code-<?php echo $i ?>">
         <div class="frame-file">
-          <?php $filePath = $frame->getFile(); ?>
+          <?php $filePath = $tpl->replaceFileRootPath($frame->getFile()); ?>
           <?php if ($filePath && $editorHref = $handler->getEditorHref($filePath, (int) $line)): ?>
             Open:
             <a href="<?php echo $editorHref ?>" class="editor-link"<?php echo ($handler->getEditorAjax($filePath, (int) $line) ? ' data-ajax' : '') ?>>

--- a/src/Whoops/Resources/views/frame_list.html.php
+++ b/src/Whoops/Resources/views/frame_list.html.php
@@ -10,7 +10,7 @@
       </div>
 
     <div class="frame-file">
-        <?php echo $frame->getFile() ? $tpl->breakOnDelimiter('/', $tpl->shorten($tpl->escape($frame->getFile()))) : '<#unknown>' ?><!--
+        <?php echo $frame->getFile() ? $tpl->breakOnDelimiter('/', $tpl->shorten($tpl->escape($tpl->replaceFileRootPath($frame->getFile())))) : '<#unknown>' ?><!--
    --><span class="frame-line"><?php echo (int) $frame->getLine() ?></span>
     </div>
   </div>

--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -46,7 +46,7 @@ class TemplateHelper
     public function __construct()
     {
         // root path for ordinary composer projects
-        $this->applicationRootPath = dirname(dirname(dirname(dirname(dirname(dirname(__DIR__))))));
+        $this->applicationRootPath = $this->ordinaryRootPath();
     }
 
     /**
@@ -119,7 +119,7 @@ class TemplateHelper
     public function shorten($path)
     {
         if ($this->applicationRootPath != "/") {
-            $path = str_replace($this->applicationRootPath, '&hellip;', $path);
+            $path = str_replace(rtrim($this->applicationRootPath, '/'), '&hellip;', $path);
         }
 
         return $path;
@@ -337,7 +337,7 @@ class TemplateHelper
      */
     public function setApplicationRootPath($applicationRootPath)
     {
-        $this->applicationRootPath = $applicationRootPath;
+        $this->applicationRootPath = rtrim($applicationRootPath ?: $this->ordinaryRootPath(), '/') . '/';
     }
 
     /**
@@ -348,5 +348,20 @@ class TemplateHelper
     public function getApplicationRootPath()
     {
         return $this->applicationRootPath;
+    }
+
+    public function replaceFileRootPath($path)
+    {
+        $originalRootPath = $this->ordinaryRootPath();
+        $applicationRootPath = $this->getApplicationRootPath();
+
+        return $originalRootPath !== $applicationRootPath && mb_strpos($path, $originalRootPath) === 0
+            ? $applicationRootPath . mb_substr($path, mb_strlen($originalRootPath))
+            : $path;
+    }
+
+    public function ordinaryRootPath()
+    {
+        return dirname(dirname(dirname(dirname(dirname(dirname(__DIR__))))));
     }
 }

--- a/tests/Whoops/Util/TemplateHelperTest.php
+++ b/tests/Whoops/Util/TemplateHelperTest.php
@@ -6,6 +6,7 @@
 
 namespace Whoops\Util;
 
+use Mockery;
 use Whoops\TestCase;
 
 class TemplateHelperTest extends TestCase
@@ -85,6 +86,24 @@ class TemplateHelperTest extends TestCase
 
         $this->helper->setApplicationRootPath('/foo/bar');
         $this->assertSame('&hellip;/baz/abc.def', $this->helper->shorten($path));
+    }
+
+    /**
+     * @covers \Whoops\Util\TemplateHelper::replaceFileRootPath()
+     */
+    public function testReplaceFileRootPath()
+    {
+
+        $helper = Mockery::mock(TemplateHelper::class)->makePartial();
+        $helper->shouldReceive('ordinaryRootPath')->andReturn('/ordinary/path/');
+
+        $helper->setApplicationRootPath('/foo/bar');
+
+        $this->assertSame(
+            '/foo/bar/baz/abc.def',
+            $helper->replaceFileRootPath('/ordinary/path/baz/abc.def'));
+
+        Mockery::close();
     }
 
     /**


### PR DESCRIPTION
Hi!
Thanks for your work on this amazing package!

A lot of developers work with docker containers or virtual machines to run their web servers locally.
So when we see a Pretty Page, all the paths are wrong, and it forbids some features of Whoops.

This PR allows us to use directly the `\Whoops\Util\TemplateHelper::$applicationRootPath` to modify the display (**and editor link!**) of file's path.

So, you just have to: 
```php
$prettyHandler->setApplicationRootPath('/Users/mathieutu/Projects/MyProject');
```
to go from:
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/11351322/31536794-2d94d2ea-b000-11e7-847c-948362280793.png">

to:
<img width="1416" alt="image" src="https://user-images.githubusercontent.com/11351322/31536829-48b456e0-b000-11e7-8cd7-877946e462c4.png">

In my opinion it could be really useful to allow people to customize really quickly their experience ! 

What do you think ?
