### PR TITLE
apply PSR2 code style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 phpunit.xml
 report
 vendor
+.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,16 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+		'examples',
+		'src',
+		'tests',
+	])
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/examples/example-ajax-only.php
+++ b/examples/example-ajax-only.php
@@ -40,7 +40,7 @@ if (\Whoops\Util\Misc::isAjaxRequest()) {
     // You can also return a result compliant to the json:api spec
     // re: http://jsonapi.org/examples/#error-objects
     // tl;dr: error[] becomes errors[[]]
-   $jsonHandler->setJsonApi(true);
+    $jsonHandler->setJsonApi(true);
 
     // And push it into the stack:
     $run->pushHandler($jsonHandler);

--- a/examples/example.php
+++ b/examples/example.php
@@ -39,7 +39,7 @@ $handler->addDataTable('Ice-cream I like', [
 
 $handler->setApplicationPaths([__FILE__]);
 
-$handler->addDataTableCallback('Details', function(\Whoops\Exception\Inspector $inspector) {
+$handler->addDataTableCallback('Details', function (\Whoops\Exception\Inspector $inspector) {
     $data = array();
     $exception = $inspector->getException();
     if ($exception instanceof SomeSpecificException) {
@@ -54,16 +54,13 @@ $run->pushHandler($handler);
 
 // Example: tag all frames inside a function with their function name
 $run->pushHandler(function ($exception, $inspector, $run) {
-
     $inspector->getFrames()->map(function ($frame) {
-
         if ($function = $frame->getFunction()) {
             $frame->addComment("This frame is within function '$function'", 'cpt-obvious');
         }
 
         return $frame;
     });
-
 });
 
 $run->register();
@@ -75,7 +72,7 @@ function fooBar()
 
 function bar()
 {
-    whoops_add_stack_frame(function(){
+    whoops_add_stack_frame(function () {
         fooBar();
     });
 }

--- a/examples/lib.php
+++ b/examples/lib.php
@@ -1,4 +1,5 @@
 <?php
-function whoops_add_stack_frame($callback){
+function whoops_add_stack_frame($callback)
+{
     $callback();
 }

--- a/src/Whoops/Handler/Handler.php
+++ b/src/Whoops/Handler/Handler.php
@@ -19,7 +19,7 @@ abstract class Handler implements HandlerInterface
      * to message the handler walker.
      */
     const DONE         = 0x10; // returning this is optional, only exists for
-                               // semantic purposes
+    // semantic purposes
     const LAST_HANDLER = 0x20;
     const QUIT         = 0x30;
 

--- a/src/Whoops/Resources/views/frame_code.html.php
+++ b/src/Whoops/Resources/views/frame_code.html.php
@@ -1,15 +1,15 @@
 <?php /* Display a code block for all frames in the stack.
        * @todo: This should PROBABLY be done on-demand, lest
        * we get 200 frames to process. */ ?>
-<div class="frame-code-container <?php echo (!$has_frames ? 'empty' : '') ?>">
+<div class="frame-code-container <?php echo(!$has_frames ? 'empty' : '') ?>">
   <?php foreach ($frames as $i => $frame): ?>
     <?php $line = $frame->getLine(); ?>
-      <div class="frame-code <?php echo ($i == 0 ) ? 'active' : '' ?>" id="frame-code-<?php echo $i ?>">
+      <div class="frame-code <?php echo ($i == 0) ? 'active' : '' ?>" id="frame-code-<?php echo $i ?>">
         <div class="frame-file">
           <?php $filePath = $frame->getFile(); ?>
           <?php if ($filePath && $editorHref = $handler->getEditorHref($filePath, (int) $line)): ?>
             Open:
-            <a href="<?php echo $editorHref ?>" class="editor-link"<?php echo ($handler->getEditorAjax($filePath, (int) $line) ? ' data-ajax' : '') ?>>
+            <a href="<?php echo $editorHref ?>" class="editor-link"<?php echo($handler->getEditorAjax($filePath, (int) $line) ? ' data-ajax' : '') ?>>
               <strong><?php echo $tpl->breakOnDelimiter('/', $tpl->escape($filePath ?: '<#unknown>')) ?></strong>
             </a>
           <?php else: ?>
@@ -25,7 +25,9 @@
 
           // getFileLines can return null if there is no source code
           if ($range):
-            $range = array_map(function ($line) { return empty($line) ? ' ' : $line;}, $range);
+            $range = array_map(function ($line) {
+                return empty($line) ? ' ' : $line;
+            }, $range);
             $start = key($range) + 1;
             $code  = join("\n", $range);
         ?>

--- a/src/Whoops/Resources/views/frame_list.html.php
+++ b/src/Whoops/Resources/views/frame_list.html.php
@@ -2,8 +2,8 @@
          clicking these links/buttons will display the code view
          for that particular frame */ ?>
 <?php foreach ($frames as $i => $frame): ?>
-  <div class="frame <?php echo ($i == 0 ? 'active' : '') ?> <?php echo ($frame->isApplication() ? 'frame-application' : '') ?>" id="frame-line-<?php echo $i ?>">
-      <span class="frame-index"><?php echo (count($frames) - $i - 1) ?></span>
+  <div class="frame <?php echo($i == 0 ? 'active' : '') ?> <?php echo($frame->isApplication() ? 'frame-application' : '') ?>" id="frame-line-<?php echo $i ?>">
+      <span class="frame-index"><?php echo(count($frames) - $i - 1) ?></span>
       <div class="frame-method-info">
         <span class="frame-class"><?php echo $tpl->breakOnDelimiter('\\', $tpl->escape($frame->getClass() ?: '')) ?></span>
         <span class="frame-function"><?php echo $tpl->breakOnDelimiter('\\', $tpl->escape($frame->getFunction() ?: '')) ?></span>

--- a/src/Whoops/Resources/views/panel_left_outer.html.php
+++ b/src/Whoops/Resources/views/panel_left_outer.html.php
@@ -1,3 +1,3 @@
-<div class="panel left-panel cf <?php echo (!$has_frames ? 'empty' : '') ?>">
+<div class="panel left-panel cf <?php echo(!$has_frames ? 'empty' : '') ?>">
   <?php $tpl->render($panel_left) ?>
 </div>

--- a/tests/Whoops/Exception/FrameTest.php
+++ b/tests/Whoops/Exception/FrameTest.php
@@ -213,6 +213,6 @@ class FrameTest extends TestCase
     {
         $frame1 = $this->getFrameInstance(['line' => 1, 'file' => 'test-file.php']);
         $frame2 = $this->getFrameInstance(['line' => 1, 'file' => 'test-file.php']);
-        $this->assertTrue ($frame1->equals($frame2));
+        $this->assertTrue($frame1->equals($frame2));
     }
 }

--- a/tests/Whoops/Handler/CallbackHandlerTest.php
+++ b/tests/Whoops/Handler/CallbackHandlerTest.php
@@ -6,13 +6,14 @@ use Whoops\TestCase;
 
 class CallbackHandlerTest extends TestCase
 {
-    public function testSimplifiedBacktrace() {
-        $handler = new CallbackHandler(function($exception, $inspector, $run) {
+    public function testSimplifiedBacktrace()
+    {
+        $handler = new CallbackHandler(function ($exception, $inspector, $run) {
             return debug_backtrace();
         });
         $backtrace = $handler->handle();
         
-        foreach($backtrace as $frame) {
+        foreach ($backtrace as $frame) {
             $this->assertNotContains('call_user_func', $frame['function']);
         }
     }

--- a/tests/Whoops/Handler/JsonResponseHandlerTest.php
+++ b/tests/Whoops/Handler/JsonResponseHandlerTest.php
@@ -58,7 +58,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsWithoutFrames()
     {
-        $json = $this->getJsonResponseFromHandler($withTrace = false,$jsonApi = false);
+        $json = $this->getJsonResponseFromHandler($withTrace = false, $jsonApi = false);
 
         // Check that the response has the expected keys:
         $this->assertArrayHasKey('error', $json);
@@ -81,7 +81,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsWithFrames()
     {
-        $json = $this->getJsonResponseFromHandler($withTrace = true,$jsonApi = false);
+        $json = $this->getJsonResponseFromHandler($withTrace = true, $jsonApi = false);
 
         // Check that the trace is returned:
         $this->assertArrayHasKey('trace', $json['error']);
@@ -101,7 +101,7 @@ class JsonResponseHandlerTest extends TestCase
      */
     public function testReturnsJsonApi()
     {
-        $json = $this->getJsonResponseFromHandler($withTrace = false,$jsonApi = true);
+        $json = $this->getJsonResponseFromHandler($withTrace = false, $jsonApi = true);
 
         // Check that the response has the expected keys:
         $this->assertArrayHasKey('errors', $json);
@@ -117,6 +117,4 @@ class JsonResponseHandlerTest extends TestCase
         // Check that the trace is NOT returned:
         $this->assertArrayNotHasKey('trace', $json['errors']);
     }
-
- 
 }

--- a/tests/Whoops/Handler/PlainTextHandlerTest.php
+++ b/tests/Whoops/Handler/PlainTextHandlerTest.php
@@ -285,12 +285,14 @@ class PlainTextHandlerTest extends TestCase
             $text
         );
         // Check that the trace arguments are returned:
-        $this->assertContains(sprintf(
+        $this->assertContains(
+            sprintf(
             '%s  string(%d) "%s"',
             PlainTextHandler::VAR_DUMP_PREFIX,
             strlen('test message'),
             'test message'
-            ), $text
+            ),
+            $text
         );
     }
 
@@ -328,12 +330,14 @@ class PlainTextHandlerTest extends TestCase
         );
 
         // Check that the trace arguments are returned:
-        $this->assertContains(sprintf(
+        $this->assertContains(
+            sprintf(
             '%s  string(%d) "%s"',
             PlainTextHandler::VAR_DUMP_PREFIX,
             strlen('test message'),
             'test message'
-            ), $text
+            ),
+            $text
         );
     }
 

--- a/tests/Whoops/Handler/PrettyPageHandlerTest.php
+++ b/tests/Whoops/Handler/PrettyPageHandlerTest.php
@@ -285,7 +285,6 @@ class PrettyPageHandlerTest extends TestCase
             $handler->getEditorAjax('/foo/bar.php', 10),
             false
         );
-
     }
 
     /**

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -108,7 +108,8 @@ class RunTest extends TestCase
     public function testPushClosureBecomesHandler()
     {
         $run = $this->getRunInstance();
-        $run->pushHandler(function () {});
+        $run->pushHandler(function () {
+        });
         $this->assertInstanceOf('Whoops\\Handler\\CallbackHandler', $run->popHandler());
     }
 
@@ -212,11 +213,17 @@ class RunTest extends TestCase
         $handlerThree = $this->getHandler();
 
         $handlerOne->shouldReceive('handle')
-            ->andReturnUsing(function () use ($order) { $order[] = 1; });
+            ->andReturnUsing(function () use ($order) {
+                $order[] = 1;
+            });
         $handlerTwo->shouldReceive('handle')
-            ->andReturnUsing(function () use ($order) { $order[] = 2; });
+            ->andReturnUsing(function () use ($order) {
+                $order[] = 2;
+            });
         $handlerThree->shouldReceive('handle')
-            ->andReturnUsing(function () use ($order) { $order[] = 3; });
+            ->andReturnUsing(function () use ($order) {
+                $order[] = 3;
+            });
 
         $run->pushHandler($handlerOne);
         $run->pushHandler($handlerTwo);

--- a/tests/Whoops/TestCase.php
+++ b/tests/Whoops/TestCase.php
@@ -6,7 +6,6 @@
 
 namespace Whoops;
 
-
 class TestCase extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Whoops/Util/SystemFacadeTest.php
+++ b/tests/Whoops/Util/SystemFacadeTest.php
@@ -71,21 +71,24 @@ class SystemFacadeTest extends \PHPUnit_Framework_TestCase
     {
         self::$runtime->shouldReceive('set_error_handler')->once();
 
-        $this->facade->setErrorHandler(function(){});
+        $this->facade->setErrorHandler(function () {
+        });
     }
 
     public function test_it_delegates_error_handling_with_level_to_the_native_implementation()
     {
         self::$runtime->shouldReceive('set_error_handler')->once();
 
-        $this->facade->setErrorHandler(function(){}, E_CORE_ERROR);
+        $this->facade->setErrorHandler(function () {
+        }, E_CORE_ERROR);
     }
 
     public function test_it_delegates_exception_handling_to_the_native_implementation()
     {
         self::$runtime->shouldReceive('set_exception_handler')->once();
 
-        $this->facade->setExceptionHandler(function(){});
+        $this->facade->setExceptionHandler(function () {
+        });
     }
 
     public function test_it_delegates_restoring_the_exception_handler_to_the_native_implementation()
@@ -106,7 +109,8 @@ class SystemFacadeTest extends \PHPUnit_Framework_TestCase
     {
         self::$runtime->shouldReceive('register_shutdown_function')->once();
 
-        $this->facade->registerShutdownFunction(function(){});
+        $this->facade->registerShutdownFunction(function () {
+        });
     }
 
     public function test_it_delegates_error_reporting_to_the_native_implementation()


### PR DESCRIPTION
this PR adds a php-cs-fixer[1] config which adds PSR2 styling to all folders containing php sources.
after this config is added you can easily enforce/fix the code-style of all php files.

the second commit applies PSR2 to all files.

I selected PSR2 because it is a common standard which is easy to automate. no personal preference involved. feel free to adjust the CS rules to whatever you like most.

[1] http://cs.sensiolabs.org/