### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Whoops/Exception/FrameCollectionTest.php
+++ b/tests/Whoops/Exception/FrameCollectionTest.php
@@ -66,7 +66,7 @@ class FrameCollectionTest extends TestCase
     public function testArrayAccessExists()
     {
         $collection = $this->getFrameCollectionInstance();
-        $this->assertTrue(isset($collection[0]));
+        $this->assertArrayHasKey(0, $collection);
     }
 
     /**
@@ -167,7 +167,7 @@ class FrameCollectionTest extends TestCase
         $arr = $frames->getArray();
         $arr[0] = 'foobar';
         $newCopy = $frames->getArray();
-        $this->assertFalse($arr[0] === $newCopy);
+        $this->assertNotSame($arr[0], $newCopy);
     }
 
     /**

--- a/tests/Whoops/Exception/FrameTest.php
+++ b/tests/Whoops/Exception/FrameTest.php
@@ -100,7 +100,7 @@ class FrameTest extends TestCase
         $data  = $this->getFrameData();
         $frame = $this->getFrameInstance($data);
 
-        $this->assertEquals($frame->getFileContents(), file_get_contents($data['file']));
+        $this->assertStringEqualsFile($data['file'], $frame->getFileContents());
     }
 
     /**

--- a/tests/Whoops/Handler/PlainTextHandlerTest.php
+++ b/tests/Whoops/Handler/PlainTextHandlerTest.php
@@ -89,25 +89,25 @@ class PlainTextHandlerTest extends TestCase
         $handler = $this->getHandler();
 
         $handler->addTraceToOutput(true);
-        $this->assertEquals(true, $handler->addTraceToOutput());
+        $this->assertTrue($handler->addTraceToOutput());
 
         $handler->addTraceToOutput(false);
-        $this->assertEquals(false, $handler->addTraceToOutput());
+        $this->assertFalse($handler->addTraceToOutput());
 
         $handler->addTraceToOutput(null);
         $this->assertEquals(null, $handler->addTraceToOutput());
 
         $handler->addTraceToOutput(1);
-        $this->assertEquals(true, $handler->addTraceToOutput());
+        $this->assertTrue($handler->addTraceToOutput());
 
         $handler->addTraceToOutput(0);
-        $this->assertEquals(false, $handler->addTraceToOutput());
+        $this->assertFalse($handler->addTraceToOutput());
 
         $handler->addTraceToOutput('');
-        $this->assertEquals(false, $handler->addTraceToOutput());
+        $this->assertFalse($handler->addTraceToOutput());
 
         $handler->addTraceToOutput('false');
-        $this->assertEquals(true, $handler->addTraceToOutput());
+        $this->assertTrue($handler->addTraceToOutput());
     }
 
     /**
@@ -118,10 +118,10 @@ class PlainTextHandlerTest extends TestCase
         $handler = $this->getHandler();
 
         $handler->addTraceFunctionArgsToOutput(true);
-        $this->assertEquals(true, $handler->addTraceFunctionArgsToOutput());
+        $this->assertTrue($handler->addTraceFunctionArgsToOutput());
 
         $handler->addTraceFunctionArgsToOutput(false);
-        $this->assertEquals(false, $handler->addTraceFunctionArgsToOutput());
+        $this->assertFalse($handler->addTraceFunctionArgsToOutput());
 
         $handler->addTraceFunctionArgsToOutput(null);
         $this->assertEquals(null, $handler->addTraceFunctionArgsToOutput());
@@ -133,10 +133,10 @@ class PlainTextHandlerTest extends TestCase
         $this->assertEquals(0, $handler->addTraceFunctionArgsToOutput());
 
         $handler->addTraceFunctionArgsToOutput('');
-        $this->assertEquals(false, $handler->addTraceFunctionArgsToOutput());
+        $this->assertFalse($handler->addTraceFunctionArgsToOutput());
 
         $handler->addTraceFunctionArgsToOutput('false');
-        $this->assertEquals(true, $handler->addTraceFunctionArgsToOutput());
+        $this->assertTrue($handler->addTraceFunctionArgsToOutput());
     }
 
     /**
@@ -167,25 +167,25 @@ class PlainTextHandlerTest extends TestCase
         $handler = $this->getHandler();
 
         $handler->loggerOnly(true);
-        $this->assertEquals(true, $handler->loggerOnly());
+        $this->assertTrue($handler->loggerOnly());
 
         $handler->loggerOnly(false);
-        $this->assertEquals(false, $handler->loggerOnly());
+        $this->assertFalse($handler->loggerOnly());
 
         $handler->loggerOnly(null);
         $this->assertEquals(null, $handler->loggerOnly());
 
         $handler->loggerOnly(1);
-        $this->assertEquals(true, $handler->loggerOnly());
+        $this->assertTrue($handler->loggerOnly());
 
         $handler->loggerOnly(0);
-        $this->assertEquals(false, $handler->loggerOnly());
+        $this->assertFalse($handler->loggerOnly());
 
         $handler->loggerOnly('');
-        $this->assertEquals(false, $handler->loggerOnly());
+        $this->assertFalse($handler->loggerOnly());
 
         $handler->loggerOnly('false');
-        $this->assertEquals(true, $handler->loggerOnly());
+        $this->assertTrue($handler->loggerOnly());
     }
 
     /**


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertStringEqualsFile` when comparing a `string` and a file;
- `assertFalse` instead of comparisons with `false` keyword;
- `assertTrue` instead of comparisons with `true` keyword;
- `assertArrayHasKey` instead of `isset` function;
- `assertNotSame` instead of strict comparisons `===`.