### PR TITLE
best practice: removed php end-tags 

### DIFF
--- a/src/Whoops/Resources/views/frame_list.html.php
+++ b/src/Whoops/Resources/views/frame_list.html.php
@@ -14,4 +14,4 @@
    --><span class="frame-line"><?php echo (int) $frame->getLine() ?></span>
     </div>
   </div>
-<?php endforeach; ?>
+<?php endforeach;

--- a/src/Whoops/Resources/views/panel_left.html.php
+++ b/src/Whoops/Resources/views/panel_left.html.php
@@ -1,3 +1,4 @@
-<?php $tpl->render($header_outer) ?>
-<?php $tpl->render($frames_description) ?>
-<?php $tpl->render($frames_container) ?>
+<?php 
+$tpl->render($header_outer);
+$tpl->render($frames_description);
+$tpl->render($frames_container);


### PR DESCRIPTION
some editors automatically add newlines at the end of files and this can render whitespaces after php-end-tags which in turn can make output buffering necessary or header sending difficult