### PR TITLE
Changed key masking to display 'BLACKLISTED'

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -698,7 +698,7 @@ class PrettyPageHandler extends Handler
         $values = $superGlobal;
         foreach ($blacklisted as $key) {
             if (isset($superGlobal[$key])) {
-                $values[$key] = str_repeat('*', strlen($superGlobal[$key]));
+                $values[$key] = 'BLACKLISTED';
             }
         }
         return $values;


### PR DESCRIPTION
The reason for this is simply in the interest of security; by repeating '*' for each key's characters it makes it the slightest bit easier to tailor an attack by knowing each key's length. By displaying 'BLACKLISTED', you're both continuing to hide the specified superglobal key and mitigating a possible attack exploitation.