### PR TITLE
Improve Mobile Styles

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -459,6 +459,39 @@ kbd {
   }
 }
 
+/* Stack panels */
+@media (max-width: 600px) {
+  .panel {
+    position: static;
+    width: 100%;
+  }
+}
+
+/* Stack details tables */
+@media (max-width: 400px) {
+  .data-table,
+  .data-table tbody,
+  .data-table tbody tr,
+  .data-table tbody td {
+    display: block;
+    width: 100%;
+  }
+
+    .data-table tbody tr:first-child {
+      padding-top: 0;
+    }
+
+      .data-table tbody td:first-child,
+      .data-table tbody td:last-child {
+        padding-left: 0;
+        padding-right: 0;
+      }
+
+      .data-table tbody td:last-child {
+        padding-top: 3px;
+      }
+}
+
 .tooltipped {
   position: relative
 }

--- a/src/Whoops/Resources/views/layout.html.php
+++ b/src/Whoops/Resources/views/layout.html.php
@@ -8,6 +8,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="robots" content="noindex,nofollow"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
     <title><?php echo $tpl->escape($page_title) ?></title>
 
     <style><?php echo $stylesheet ?></style>


### PR DESCRIPTION
A couple of simple responsive styles to stack the two panels on narrow screens (and stack the two columns in the data tables on very-narrow screens), improving usability on mobile.