### PR TITLE
Add Atom URI Handler

### DIFF
--- a/docs/Open Files In An Editor.md
+++ b/docs/Open Files In An Editor.md
@@ -23,6 +23,7 @@ The following editors are currently supported by default.
 - `textmate` - Textmate
 - `xdebug`   - xdebug (uses [xdebug.file_link_format](http://xdebug.org/docs/all_settings#file_link_format))
 - `vscode`   - VSCode (ref [Opening VS Code with URLs](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls))
+- `atom`     - Atom (ref [Add core URI handlers](https://github.com/atom/atom/pull/15935))
 
 Adding your own editor is simple:
 

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -96,6 +96,7 @@ class PrettyPageHandler extends Handler
         "phpstorm" => "phpstorm://open?file=%file&line=%line",
         "idea"     => "idea://open?file=%file&line=%line",
         "vscode"   => "vscode://file/%file:%line",
+        "atom"     => "atom://core/open/file?filename=%file&line=%line",
     ];
 
     /**


### PR DESCRIPTION
Noticed this was missing and did a bit of searching to find this has been implemented in Atom: https://github.com/atom/atom/pull/15935