### PR TITLE
CSS z-index fix

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -12,6 +12,11 @@ body {
     text-decoration: none;
   }
 
+.Whoops.container {
+    position: relative;
+    z-index: 9999999999;
+}
+
 .panel {
     overflow-y: scroll;
     height: 100%;


### PR DESCRIPTION
Added a very high z-index to .Whoops.container so that the whoops page never appears under sticky headers or have any other misc content float over the page.