### PR TITLE
Switch from div to span to allow copy and paste

### DIFF
--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -104,7 +104,7 @@ class TemplateHelper
     {
         $parts = explode($delimiter, $s);
         foreach ($parts as &$part) {
-            $part = '<div class="delimiter">' . $part . '</div>';
+            $part = '<span class="delimiter">' . $part . '</span>';
         }
 
         return implode($delimiter, $parts);

--- a/tests/Whoops/Util/TemplateHelperTest.php
+++ b/tests/Whoops/Util/TemplateHelperTest.php
@@ -69,7 +69,7 @@ class TemplateHelperTest extends TestCase
     public function testBreakOnDelimiter()
     {
         $this->assertSame(
-            '<div class="delimiter">abc</div>-<div class="delimiter">123</div>-<div class="delimiter">456</div>',
+            '<span class="delimiter">abc</span>-<span class="delimiter">123</span>-<span class="delimiter">456</span>',
             $this->helper->breakOnDelimiter('-', 'abc-123-456')
         );
     }


### PR DESCRIPTION
The use of divs where file paths are displayed causes newlines to be placed at each delimiter when copying and pasting those file paths. Switching to span no longer exposes this problem, and has no impact on the output displayed to the user.