### PR TITLE
Do not block other shutdown handlers

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -375,6 +375,7 @@ final class Run implements RunInterface
         if ($error && Misc::isLevelFatal($error['type'])) {
             // If there was a fatal error,
             // it was not handled in handleError yet.
+            $this->allowQuit = false;
             $this->handleError(
                 $error['type'],
                 $error['message'],


### PR DESCRIPTION
Here is my case:
I write a robust console script. It uses a lock file to prevent overlapping of several instances.
So, the lock file needs to be deleted every time the script finishes (with error or not).
In php we do such stuff like that:
```php
        register_shutdown_function(function ($lockFile) {
            unlink($lockFile);
        }, $this->lockFile);
```
No whoops -> works well
Whoops and no errors -> works well
Whoops and simple exceptions -> works well
Whoops and some nasty errors like `Allowed memory size of XXXXX bytes exhausted` -> fail. My callback is not executed.
This happens because exit(1) is being called from Whoop's shutdown handler and as a result any other shutdown handlers are blocked.
Any shutdown handlers registered before whoops are executed, so the whole situation makes little sense to me.

This fix LOOKS like a correct way to address this issue. Forgive me if I'm wrong :)