### PR TITLE
Updated default header size to big debug strings

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -38,7 +38,7 @@ header {
   box-sizing: border-box;
   background-color: #2a2a2a;
   padding: 35px 40px;
-  max-height: 180px;
+  max-height: 500px;
   overflow: hidden;
   transition: 0.5s;
 }


### PR DESCRIPTION
Hi! 

**Many** errors in `Laravel` have a **huge** number of rows and resize action (on hover) in div is **very** slow.

To speed up the development and ease the work of programmers, I suggest immediately making a window above!

### before

<img width="651" alt="screen shot 2018-04-19 at 17 59 18" src="https://user-images.githubusercontent.com/365029/38993087-16b644c4-43fc-11e8-929c-e9019104697c.png">


### after

<img width="649" alt="screen shot 2018-04-19 at 17 59 32" src="https://user-images.githubusercontent.com/365029/38993098-1d377048-43fc-11e8-8555-c2d5404626d5.png">
