### PR TITLE
editor callback: allow to return empty value

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -507,6 +507,10 @@ class PrettyPageHandler extends Handler
                 $callback = call_user_func($this->editors[$this->editor], $filePath, $line);
             }
 
+            if (empty($callback)) {
+                return [];
+            }
+
             if (is_string($callback)) {
                 return [
                     'ajax' => false,

--- a/tests/Whoops/Handler/PrettyPageHandlerTest.php
+++ b/tests/Whoops/Handler/PrettyPageHandlerTest.php
@@ -288,6 +288,14 @@ class PrettyPageHandlerTest extends TestCase
             false
         );
 
+        $handler->setEditor(function ($file, $line) {
+            return false;
+        });
+
+        $this->assertEquals(
+            $handler->getEditorHref('/foo/bar.php', 10),
+            false
+        );
     }
 
     /**


### PR DESCRIPTION
In our case we have some virtual paths (stream wrappers), and some of them can be converted into an editor url, others can not.

So I suggest to allow returning an empty value from editor callback.