### PR TITLE
Remove superfluous is_file() check

### DIFF
--- a/src/Whoops/Exception/Frame.php
+++ b/src/Whoops/Exception/Frame.php
@@ -119,11 +119,6 @@ class Frame implements Serializable
                 return null;
             }
 
-            // Return null if the file doesn't actually exist.
-            if (!is_file($filePath)) {
-                return null;
-            }
-
             $this->fileContentsCache = file_get_contents($filePath);
         }
 


### PR DESCRIPTION
this lines were added in the past to handle the case where $filePath is „Unknown“, see 
https://github.com/filp/whoops/commit/f83625d66aa85dd4a49260696930a3c3ea2c1af3

Later on a additional check for „Unknown“ was added for open_basedir related errors
https://github.com/filp/whoops/commit/1c0ffa00594622d7d1f4368de5ae2249617e5167

Therefore the lines added in the first place are no longer usefull.

Additionally there is a feature request in https://github.com/filp/whoops/issues/586 for which the mentioned lines are getting in our way.