### PR TITLE
Added noindex http headers

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -300,6 +300,7 @@ final class Run implements RunInterface
 
                 // Send any headers if needed:
                 if (Misc::canSendHeaders() && $handlerContentType) {
+                    header("X-Robots-Tag: noindex, nofollow");
                     header("Content-Type: {$handlerContentType}");
                 }
             }


### PR DESCRIPTION
Its redundant a bit, but better be safe then sorry.

Proxies/webserver might override the http status code and therefore error pages could show up in e.g. google search index

https://www.google.de/search?q=Whoops%21+There+was+an+error

Refs https://github.com/filp/whoops/issues/604