### PR TITLE
add previous exception messages to plain text output

### DIFF
--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -49,6 +49,11 @@ class PlainTextHandler extends Handler
     /**
      * @var bool
      */
+    private $addPreviousToOutput = true;
+
+    /**
+     * @var bool
+     */
     private $loggerOnly = false;
 
     /**
@@ -115,6 +120,21 @@ class PlainTextHandler extends Handler
     }
 
     /**
+     * Add previous exceptions to output.
+     * @param  bool|null $addPreviousToOutput
+     * @return bool|$this
+     */
+    public function addPreviousToOutput($addPreviousToOutput = null)
+    {
+        if (func_num_args() == 0) {
+            return $this->addPreviousToOutput;
+        }
+
+        $this->addPreviousToOutput = (bool) $addPreviousToOutput;
+        return $this;
+    }
+
+    /**
      * Add error trace function arguments to output.
      * Set to True for all frame args, or integer for the n first frame args.
      * @param  bool|integer|null $addTraceFunctionArgsToOutput
@@ -151,14 +171,18 @@ class PlainTextHandler extends Handler
     public function generateResponse()
     {
         $exception = $this->getException();
-        return sprintf(
-            "%s: %s in file %s on line %d%s\n",
-            get_class($exception),
-            $exception->getMessage(),
-            $exception->getFile(),
-            $exception->getLine(),
-            $this->getTraceOutput()
-        );
+        $message = $this->getExceptionOutput($exception);
+
+        if ($this->addPreviousToOutput) {
+            $previous = $exception->getPrevious();
+            while ($previous) {
+                $message .= "\nBefore: " . $this->getExceptionOutput($previous);
+                $previous = $previous->getPrevious();
+            }
+        }
+
+
+        return $message . $this->getTraceOutput() . "\n";
     }
 
     /**
@@ -282,6 +306,22 @@ class PlainTextHandler extends Handler
         }
 
         return $response;
+    }
+
+    /**
+     * Get the exception as plain text.
+     * @param \Throwable $exception
+     * @return string
+     */
+    protected function getExceptionOutput($exception)
+    {
+        return sprintf(
+            "%s: %s in file %s on line %d",
+            get_class($exception),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
+        );
     }
 
     /**

--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -176,7 +176,7 @@ class PlainTextHandler extends Handler
         if ($this->addPreviousToOutput) {
             $previous = $exception->getPrevious();
             while ($previous) {
-                $message .= "\nBefore: " . $this->getExceptionOutput($previous);
+                $message .= "\n\nCaused by\n" . $this->getExceptionOutput($previous);
                 $previous = $previous->getPrevious();
             }
         }
@@ -313,7 +313,7 @@ class PlainTextHandler extends Handler
      * @param \Throwable $exception
      * @return string
      */
-    protected function getExceptionOutput($exception)
+    private function getExceptionOutput($exception)
     {
         return sprintf(
             "%s: %s in file %s on line %d",

--- a/tests/Whoops/Handler/PlainTextHandlerTest.php
+++ b/tests/Whoops/Handler/PlainTextHandlerTest.php
@@ -267,7 +267,7 @@ class PlainTextHandlerTest extends TestCase
                 'Outer exception message',
                 __FILE__,
                 258,
-                'Before: ' . RuntimeException::class,
+                "\nCaused by\n" . RuntimeException::class,
                 'Inner exception message',
                 __FILE__,
                 258


### PR DESCRIPTION
fixes #608 

Can be disabled via `PlainTextHandler::addPreviousToOutput(false)` and
adds lines between the exception and the trace containing the exception
and line of creator.

The method `Inspector::getFrames()` already appends all frames from the
previous exceptions. So there is no need in adding the trace for each
previous exception.

IMO the test tests something that it should not test: the output of the
line number. But that should be in a separate PR. I've at least added
constants for the line numbers so that you only have to change them once
for all tests.