### PR TITLE
use fqcn in example

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,11 +84,8 @@ $ composer install</code></pre>
           </p>
 <pre class="prettyprint"><code class="language-php">require __DIR__ . "/vendor/autoload.php";
 
-use Whoops\Handler\PrettyPageHandler;
-use Whoops\Handler\JsonResponseHandler;
-
-$run     = new Whoops\Run;
-$handler = new PrettyPageHandler;
+$run     = new \Whoops\Run;
+$handler = new \Whoops\Handler\PrettyPageHandler;
 
 // Add some custom tables with relevant info about your application,
 // that could prove useful in the error page:
@@ -107,8 +104,8 @@ $run->pushHandler($handler);
 // first in the stack, it will be executed before the error
 // page handler, and will have a chance to decide if anything
 // needs to be done.
-if (Whoops\Util\Misc::isAjaxRequest()) {
-  $run->pushHandler(new JsonResponseHandler);
+if (\Whoops\Util\Misc::isAjaxRequest()) {
+  $run->pushHandler(new \Whoops\Handler\JsonResponseHandler);
 }
 
 // Register the handler with PHP, and you're set!


### PR DESCRIPTION
use full qualified class-names in example codes to make them more self-contained and also work in namespaced code