### PR TITLE
Prevent „strlen() expects parameter 1 to be string, array given“ Warning

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -705,7 +705,7 @@ class PrettyPageHandler extends Handler
 
         $values = $superGlobal;
         foreach ($blacklisted as $key) {
-            if (isset($superGlobal[$key])) {
+            if (isset($superGlobal[$key]) && is_string($superGlobal[$key])) {
                 $values[$key] = str_repeat('*', strlen($superGlobal[$key]));
             }
         }


### PR DESCRIPTION
Should fix https://github.com/filp/whoops/issues/627

The build error is not related