### PR TITLE
feat!: add append and prepend handler instead of reverse execution

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -29,7 +29,7 @@ final class Run implements RunInterface
     /**
      * @var HandlerInterface[]
      */
-    private $handlerStack = [];
+    private $handlerQueue = [];
 
     private $silencedPatterns = [];
 
@@ -41,7 +41,7 @@ final class Run implements RunInterface
     }
 
     /**
-     * Prepends a handler to the start of the stack
+     * Prepends a handler to the start of the queue
      *
      * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
      * @param  Callable|HandlerInterface $handler
@@ -54,7 +54,7 @@ final class Run implements RunInterface
     }
 
     /**
-     * Appends a handler to the end of the stack
+     * Appends a handler to the end of the queue
      *
      * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
      * @param  Callable|HandlerInterface $handler
@@ -62,12 +62,12 @@ final class Run implements RunInterface
      */
     public function appendHandler($handler)
     {
-        array_push($this->handlerStack, $this->resolveHandler($handler));
+        array_push($this->handlerQueue, $this->resolveHandler($handler));
         return $this;
     }
 
     /**
-     * Prepends a handler to the start of the stack
+     * Prepends a handler to the start of the queue
      *
      * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
      * @param  Callable|HandlerInterface $handler
@@ -75,7 +75,7 @@ final class Run implements RunInterface
      */
     public function prependHandler($handler)
     {
-        array_unshift($this->handlerStack, $this->resolveHandler($handler));
+        array_unshift($this->handlerQueue, $this->resolveHandler($handler));
         return $this;
     }
 
@@ -103,43 +103,43 @@ final class Run implements RunInterface
     }
 
     /**
-     * Removes the last handler in the stack and returns it.
+     * Removes the last handler in the queue and returns it.
      * Returns null if there"s nothing else to pop.
      * @return null|HandlerInterface
      */
     public function popHandler()
     {
-        return array_pop($this->handlerStack);
+        return array_pop($this->handlerQueue);
     }
 
     /**
-     * Removes the first handler in the stack and returns it.
+     * Removes the first handler in the queue and returns it.
      * Returns null if there"s nothing else to shift.
      * @return null|HandlerInterface
      */
     public function shiftHandler()
     {
-        return array_shift($this->handlerStack);
+        return array_shift($this->handlerQueue);
     }
 
     /**
      * Returns an array with all handlers, in the
-     * order they were added to the stack.
+     * order they were added to the queue.
      * @return array
      */
     public function getHandlers()
     {
-        return $this->handlerStack;
+        return $this->handlerQueue;
     }
 
     /**
-     * Clears all handlers in the handlerStack, including
+     * Clears all handlers in the handlerQueue, including
      * the default PrettyPage handler.
      * @return Run
      */
     public function clearHandlers()
     {
-        $this->handlerStack = [];
+        $this->handlerQueue = [];
         return $this;
     }
 
@@ -308,7 +308,7 @@ final class Run implements RunInterface
         $handlerResponse = null;
         $handlerContentType = null;
 
-        foreach ($this->handlerStack as $handler) {
+        foreach ($this->handlerQueue as $handler) {
             $handler->setRun($this);
             $handler->setInspector($inspector);
             $handler->setException($exception);

--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -41,13 +41,52 @@ final class Run implements RunInterface
     }
 
     /**
-     * Pushes a handler to the end of the stack
+     * Prepends a handler to the start of the stack
+     *
+     * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
+     * @param  Callable|HandlerInterface $handler
+     * @return Run
+     * @deprecated use appendHandler and prependHandler instead
+     */
+    public function pushHandler($handler)
+    {
+        return $this->prependHandler($handler);
+    }
+
+    /**
+     * Appends a handler to the end of the stack
      *
      * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
      * @param  Callable|HandlerInterface $handler
      * @return Run
      */
-    public function pushHandler($handler)
+    public function appendHandler($handler)
+    {
+        array_push($this->handlerStack, $this->resolveHandler($handler));
+        return $this;
+    }
+
+    /**
+     * Prepends a handler to the start of the stack
+     *
+     * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
+     * @param  Callable|HandlerInterface $handler
+     * @return Run
+     */
+    public function prependHandler($handler)
+    {
+        array_unshift($this->handlerStack, $this->resolveHandler($handler));
+        return $this;
+    }
+
+    /**
+     * Create a CallbackHandler from callable and throw if handler is invalid
+     *
+     * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
+     * @param Callable|HandlerInterface $handler
+     * @return HandlerInterface
+     */
+    private function resolveHandler($handler)
     {
         if (is_callable($handler)) {
             $handler = new CallbackHandler($handler);
@@ -55,13 +94,12 @@ final class Run implements RunInterface
 
         if (!$handler instanceof HandlerInterface) {
             throw new InvalidArgumentException(
-                  "Argument to " . __METHOD__ . " must be a callable, or instance of "
+                "Argument to " . __METHOD__ . " must be a callable, or instance of "
                 . "Whoops\\Handler\\HandlerInterface"
             );
         }
 
-        $this->handlerStack[] = $handler;
-        return $this;
+        return $handler;
     }
 
     /**
@@ -72,6 +110,16 @@ final class Run implements RunInterface
     public function popHandler()
     {
         return array_pop($this->handlerStack);
+    }
+
+    /**
+     * Removes the first handler in the stack and returns it.
+     * Returns null if there"s nothing else to shift.
+     * @return null|HandlerInterface
+     */
+    public function shiftHandler()
+    {
+        return array_shift($this->handlerStack);
     }
 
     /**
@@ -260,7 +308,7 @@ final class Run implements RunInterface
         $handlerResponse = null;
         $handlerContentType = null;
 
-        foreach (array_reverse($this->handlerStack) as $handler) {
+        foreach ($this->handlerStack as $handler) {
             $handler->setRun($this);
             $handler->setInspector($inspector);
             $handler->setException($exception);

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -82,8 +82,8 @@ class RunTest extends TestCase
         $handlerOne = $this->getHandler();
         $handlerTwo = $this->getHandler();
 
-        $run->pushHandler($handlerOne);
-        $run->pushHandler($handlerTwo);
+        $run->prependHandler($handlerOne);
+        $run->prependHandler($handlerTwo);
 
         $handlers = $run->getHandlers();
 
@@ -99,7 +99,7 @@ class RunTest extends TestCase
     public function testPushInvalidHandler()
     {
         $run = $this->getRunInstance();
-        $run->pushHandler($banana = 'actually turnip');
+        $run->prependHandler($banana = 'actually turnip');
     }
 
     /**
@@ -108,7 +108,7 @@ class RunTest extends TestCase
     public function testPushClosureBecomesHandler()
     {
         $run = $this->getRunInstance();
-        $run->pushHandler(function () {});
+        $run->prependHandler(function () {});
         $this->assertInstanceOf('Whoops\\Handler\\CallbackHandler', $run->popHandler());
     }
 
@@ -124,9 +124,9 @@ class RunTest extends TestCase
         $handlerTwo   = $this->getHandler();
         $handlerThree = $this->getHandler();
 
-        $run->pushHandler($handlerOne);
-        $run->pushHandler($handlerTwo);
-        $run->pushHandler($handlerThree);
+        $run->appendHandler($handlerOne);
+        $run->appendHandler($handlerTwo);
+        $run->appendHandler($handlerThree);
 
         $this->assertSame($handlerThree, $run->popHandler());
         $this->assertSame($handlerTwo, $run->popHandler());
@@ -164,7 +164,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->pushHandler($handler);
+        $run->prependHandler($handler);
 
         $run->unregister();
         throw $this->getException("I'm not supposed to be caught!");
@@ -183,10 +183,10 @@ class RunTest extends TestCase
         $handlerThree = $this->getHandler();
         $handlerFour  = $this->getHandler();
 
-        $run->pushHandler($handlerOne);
-        $run->pushHandler($handlerTwo);
-        $run->pushHandler($handlerThree);
-        $run->pushHandler($handlerFour);
+        $run->appendHandler($handlerOne);
+        $run->appendHandler($handlerTwo);
+        $run->appendHandler($handlerThree);
+        $run->appendHandler($handlerFour);
 
         $handlers = $run->getHandlers();
 
@@ -218,9 +218,9 @@ class RunTest extends TestCase
         $handlerThree->shouldReceive('handle')
             ->andReturnUsing(function () use ($order) { $order[] = 3; });
 
-        $run->pushHandler($handlerOne);
-        $run->pushHandler($handlerTwo);
-        $run->pushHandler($handlerThree);
+        $run->prependHandler($handlerOne);
+        $run->prependHandler($handlerTwo);
+        $run->prependHandler($handlerThree);
 
         // Get an exception to be handled, and verify that the handlers
         // are given the handler, and in the inverse order they were
@@ -239,8 +239,8 @@ class RunTest extends TestCase
         $handlerOne = $this->getHandler();
         $handlerTwo = $this->getHandler();
 
-        $run->pushHandler($handlerOne);
-        $run->pushHandler($handlerTwo);
+        $run->prependHandler($handlerOne);
+        $run->prependHandler($handlerTwo);
 
         $test = $this;
         $handlerOne
@@ -268,7 +268,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->pushHandler($handler);
+        $run->prependHandler($handler);
 
         $test = $this;
         $handler
@@ -289,7 +289,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->pushHandler($handler);
+        $run->prependHandler($handler);
 
         $test = $this;
         $handler
@@ -318,7 +318,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->pushHandler($handler);
+        $run->prependHandler($handler);
 
         $test = $this;
         $handler
@@ -344,7 +344,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->pushHandler($handler);
+        $run->prependHandler($handler);
 
         $test = $this;
         $handler
@@ -367,7 +367,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->pushHandler($handler);
+        $run->prependHandler($handler);
 
         @strpos();
 
@@ -402,7 +402,7 @@ class RunTest extends TestCase
     public function testOutputIsSent()
     {
         $run = $this->getRunInstance();
-        $run->pushHandler(function () {
+        $run->prependHandler(function () {
             echo "hello there";
         });
 
@@ -419,7 +419,7 @@ class RunTest extends TestCase
     {
         $run = $this->getRunInstance();
         $run->writeToOutput(false);
-        $run->pushHandler(function () {
+        $run->prependHandler(function () {
             echo "hello there";
         });
 


### PR DESCRIPTION
see #580 

BREAKING CHANGE: since `pushHandler()` was actually prepending handlers
it is now an alias for prependHandler but `popHandler()` is still
removing the last handler.

This should make the interface clearer: pushing (append) is now executed at the end while prepend is alias by the deprecated `pushHandler()` method.

People using the deprecated `pushHandler()` method and `popHandler()` should update the implementation to use `shiftHandler()` and `prependHandler()`.