### PR TITLE
Change deprecated pushHandler to prependHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you are not using any of these frameworks, here's a very simple way to instal
 
     ```php
     $whoops = new \Whoops\Run;
-    $whoops->pushHandler(new \Whoops\Handler\PrettyPageHandler);
+    $whoops->prependHandler(new \Whoops\Handler\PrettyPageHandler);
     $whoops->register();
     ```
 


### PR DESCRIPTION
On https://github.com/filp/whoops/blob/master/src/Whoops/Run.php on lines 43-54, it states that pushHandler is being replaced with prependHandler.

Specifically:
* @deprecated use appendHandler and prependHandler instead
     */
    public function pushHandler($handler)
    {
        return $this->prependHandler($handler);
    }