### PR TITLE
Change deprecated pushHandler to prependHandler

### DIFF
--- a/examples/example.php
+++ b/examples/example.php
@@ -50,10 +50,10 @@ $handler->addDataTableCallback('Details', function(\Whoops\Exception\Inspector $
     return $data;
 });
 
-$run->pushHandler($handler);
+$run->prependHandler($handler);
 
 // Example: tag all frames inside a function with their function name
-$run->pushHandler(function ($exception, $inspector, $run) {
+$run->prependHandler(function ($exception, $inspector, $run) {
 
     $inspector->getFrames()->map(function ($frame) {
 


### PR DESCRIPTION
On https://github.com/filp/whoops/blob/master/src/Whoops/Run.php on lines 43-54, it states that pushHandler is being replaced with prependHandler.

Specifically:

```
* @deprecated use appendHandler and prependHandler instead
     */
    public function pushHandler($handler)
    {
        return $this->prependHandler($handler);
    }
```