### PR TITLE
Change deprecated pushHandler to prependHandler

### DIFF
--- a/examples/example-ajax-only.php
+++ b/examples/example-ajax-only.php
@@ -26,7 +26,7 @@ $run = new Run();
 
 // We want the error page to be shown by default, if this is a
 // regular request, so that's the first thing to go into the stack:
-$run->pushHandler(new PrettyPageHandler());
+$run->prependHandler(new PrettyPageHandler());
 
 // Now, we want a second handler that will run before the error page,
 // and immediately return an error message in JSON format, if something
@@ -42,8 +42,8 @@ if (\Whoops\Util\Misc::isAjaxRequest()) {
     // tl;dr: error[] becomes errors[[]]
    $jsonHandler->setJsonApi(true);
 
-    // And push it into the stack:
-    $run->pushHandler($jsonHandler);
+    // And prepend it into the stack:
+    $run->prependHandler($jsonHandler);
 }
 
 // That's it! Register Whoops and throw a dummy exception:


### PR DESCRIPTION
On https://github.com/filp/whoops/blob/master/src/Whoops/Run.php on lines 43-54, it states that pushHandler is being replaced with prependHandler.

Specifically:
```
* @deprecated use appendHandler and prependHandler instead
     */
    public function pushHandler($handler)
    {
        return $this->prependHandler($handler);
    }
```