### PR TITLE
Implemented automatic editor configuration if Xdebug is available.

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -126,6 +126,9 @@ class PrettyPageHandler extends Handler
             $this->editors['xdebug'] = function ($file, $line) {
                 return str_replace(['%f', '%l'], [$file, $line], ini_get('xdebug.file_link_format'));
             };
+
+            // If xdebug is available, use it as default editor.
+            $this->setEditor('xdebug');
         }
 
         // Add the default, local resource search path:


### PR DESCRIPTION
This pull request adds the feature to configure Xdebug as default editor, if the `xdebug.file_link_format` option is set, and Xdebug is loaded.

This should not break any existing functionality as the editor can be easily overwritten with the `setEditor` method.

This was previously mentioned in #590.