### PR TITLE
Fix BC break introduced in 2.4.0 release

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -29,7 +29,7 @@ final class Run implements RunInterface
     /**
      * @var HandlerInterface[]
      */
-    private $handlerQueue = [];
+    private $handlerStack = [];
 
     private $silencedPatterns = [];
 
@@ -41,7 +41,7 @@ final class Run implements RunInterface
     }
 
     /**
-     * Prepends a handler to the start of the queue
+     * Pushes a handler to the end of the stack
      *
      * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
      * @param  Callable|HandlerInterface $handler
@@ -54,7 +54,7 @@ final class Run implements RunInterface
     }
 
     /**
-     * Appends a handler to the end of the queue
+     * Adds a handler to be executed as last.
      *
      * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
      * @param  Callable|HandlerInterface $handler
@@ -62,12 +62,12 @@ final class Run implements RunInterface
      */
     public function appendHandler($handler)
     {
-        array_push($this->handlerQueue, $this->resolveHandler($handler));
+        array_unshift($this->handlerStack, $this->resolveHandler($handler));
         return $this;
     }
 
     /**
-     * Prepends a handler to the start of the queue
+     * Adds a handler to be executed as first.
      *
      * @throws InvalidArgumentException  If argument is not callable or instance of HandlerInterface
      * @param  Callable|HandlerInterface $handler
@@ -75,7 +75,7 @@ final class Run implements RunInterface
      */
     public function prependHandler($handler)
     {
-        array_unshift($this->handlerQueue, $this->resolveHandler($handler));
+        $this->handlerStack[] = $this->resolveHandler($handler);
         return $this;
     }
 
@@ -103,43 +103,57 @@ final class Run implements RunInterface
     }
 
     /**
-     * Removes the last handler in the queue and returns it.
+     * Removes the last handler in the stack and returns it.
+     * As implementation is using stack, the last element added to the stack
+     * is executed as first.
+     *
      * Returns null if there"s nothing else to pop.
      * @return null|HandlerInterface
      */
     public function popHandler()
     {
-        return array_pop($this->handlerQueue);
+        return array_pop($this->handlerStack);
     }
 
     /**
-     * Removes the first handler in the queue and returns it.
+     * Removes the first handler in the stack and returns it.
+     * As implementation is using stack, the first element added to the stack
+     * is executed as last.
+     *
      * Returns null if there"s nothing else to shift.
      * @return null|HandlerInterface
      */
     public function shiftHandler()
     {
-        return array_shift($this->handlerQueue);
+        return array_shift($this->handlerStack);
     }
 
     /**
      * Returns an array with all handlers, in the
-     * order they were added to the queue.
+     * order they were added to the stack.
+     *
+     * As stack implementation is used, handlers are executed from the end of that list
+     * (from the top of the stack).
+     *
+     * You can use:
+     * - appendHandler to add handler to be executed as last (add to the top of the stack)
+     * - prependHandler to add the handler to be executed as first (add to the bottom of the stack)
+     *
      * @return array
      */
     public function getHandlers()
     {
-        return $this->handlerQueue;
+        return $this->handlerStack;
     }
 
     /**
-     * Clears all handlers in the handlerQueue, including
+     * Clears all handlers in the handlerStack, including
      * the default PrettyPage handler.
      * @return Run
      */
     public function clearHandlers()
     {
-        $this->handlerQueue = [];
+        $this->handlerStack = [];
         return $this;
     }
 
@@ -303,13 +317,13 @@ final class Run implements RunInterface
         // we might want to send it straight away to the client,
         // or return it silently.
         $this->system->startOutputBuffering();
-        
+
         // Just in case there are no handlers:
         $handlerResponse = null;
         $handlerContentType = null;
 
         try {
-            foreach ($this->handlerQueue as $handler) {
+            foreach (array_reverse($this->handlerStack) as $handler) {
                 $handler->setRun($this);
                 $handler->setInspector($inspector);
                 $handler->setException($exception);

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -82,8 +82,8 @@ class RunTest extends TestCase
         $handlerOne = $this->getHandler();
         $handlerTwo = $this->getHandler();
 
-        $run->prependHandler($handlerOne);
-        $run->prependHandler($handlerTwo);
+        $run->pushHandler($handlerOne);
+        $run->pushHandler($handlerTwo);
 
         $handlers = $run->getHandlers();
 
@@ -99,7 +99,7 @@ class RunTest extends TestCase
     public function testPushInvalidHandler()
     {
         $run = $this->getRunInstance();
-        $run->prependHandler($banana = 'actually turnip');
+        $run->pushHandler($banana = 'actually turnip');
     }
 
     /**
@@ -108,7 +108,7 @@ class RunTest extends TestCase
     public function testPushClosureBecomesHandler()
     {
         $run = $this->getRunInstance();
-        $run->prependHandler(function () {});
+        $run->pushHandler(function () {});
         $this->assertInstanceOf('Whoops\\Handler\\CallbackHandler', $run->popHandler());
     }
 
@@ -124,9 +124,9 @@ class RunTest extends TestCase
         $handlerTwo   = $this->getHandler();
         $handlerThree = $this->getHandler();
 
-        $run->appendHandler($handlerOne);
-        $run->appendHandler($handlerTwo);
-        $run->appendHandler($handlerThree);
+        $run->pushHandler($handlerOne);
+        $run->pushHandler($handlerTwo);
+        $run->pushHandler($handlerThree);
 
         $this->assertSame($handlerThree, $run->popHandler());
         $this->assertSame($handlerTwo, $run->popHandler());
@@ -164,7 +164,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->prependHandler($handler);
+        $run->pushHandler($handler);
 
         $run->unregister();
         throw $this->getException("I'm not supposed to be caught!");
@@ -183,10 +183,10 @@ class RunTest extends TestCase
         $handlerThree = $this->getHandler();
         $handlerFour  = $this->getHandler();
 
-        $run->appendHandler($handlerOne);
-        $run->appendHandler($handlerTwo);
-        $run->appendHandler($handlerThree);
-        $run->appendHandler($handlerFour);
+        $run->pushHandler($handlerOne);
+        $run->pushHandler($handlerTwo);
+        $run->pushHandler($handlerThree);
+        $run->pushHandler($handlerFour);
 
         $handlers = $run->getHandlers();
 
@@ -218,9 +218,9 @@ class RunTest extends TestCase
         $handlerThree->shouldReceive('handle')
             ->andReturnUsing(function () use ($order) { $order[] = 3; });
 
-        $run->prependHandler($handlerOne);
-        $run->prependHandler($handlerTwo);
-        $run->prependHandler($handlerThree);
+        $run->pushHandler($handlerOne);
+        $run->pushHandler($handlerTwo);
+        $run->pushHandler($handlerThree);
 
         // Get an exception to be handled, and verify that the handlers
         // are given the handler, and in the inverse order they were
@@ -239,8 +239,8 @@ class RunTest extends TestCase
         $handlerOne = $this->getHandler();
         $handlerTwo = $this->getHandler();
 
-        $run->prependHandler($handlerOne);
-        $run->prependHandler($handlerTwo);
+        $run->pushHandler($handlerOne);
+        $run->pushHandler($handlerTwo);
 
         $test = $this;
         $handlerOne
@@ -268,7 +268,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->prependHandler($handler);
+        $run->pushHandler($handler);
 
         $test = $this;
         $handler
@@ -289,7 +289,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->prependHandler($handler);
+        $run->pushHandler($handler);
 
         $test = $this;
         $handler
@@ -318,7 +318,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->prependHandler($handler);
+        $run->pushHandler($handler);
 
         $test = $this;
         $handler
@@ -344,7 +344,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->prependHandler($handler);
+        $run->pushHandler($handler);
 
         $test = $this;
         $handler
@@ -367,7 +367,7 @@ class RunTest extends TestCase
         $run->register();
 
         $handler = $this->getHandler();
-        $run->prependHandler($handler);
+        $run->pushHandler($handler);
 
         @strpos();
 
@@ -394,7 +394,7 @@ class RunTest extends TestCase
             $this->assertSame(99, $e->getLine());
         }
     }
-    
+
     /**
      * @covers Whoops\Run::handleException
      * @covers Whoops\Run::writeToOutput
@@ -402,7 +402,7 @@ class RunTest extends TestCase
     public function testOutputIsSent()
     {
         $run = $this->getRunInstance();
-        $run->prependHandler(function () {
+        $run->pushHandler(function () {
             echo "hello there";
         });
 
@@ -419,7 +419,7 @@ class RunTest extends TestCase
     {
         $run = $this->getRunInstance();
         $run->writeToOutput(false);
-        $run->prependHandler(function () {
+        $run->pushHandler(function () {
             echo "hello there";
         });
 
@@ -454,5 +454,59 @@ class RunTest extends TestCase
     public function testSendHttpCodeWrongCode()
     {
         $this->getRunInstance()->sendHttpCode(1337);
+    }
+
+    public function testAppendHandler()
+    {
+        $run       = $this->getRunInstance();
+        $exception = $this->getException();
+        $order     = new ArrayObject();
+
+        $handlerOne   = $this->getHandler();
+        $handlerTwo   = $this->getHandler();
+        $handlerThree = $this->getHandler();
+
+        $handlerOne->shouldReceive('handle')
+            ->andReturnUsing(function () use ($order) { $order[] = 1; });
+        $handlerTwo->shouldReceive('handle')
+            ->andReturnUsing(function () use ($order) { $order[] = 2; });
+        $handlerThree->shouldReceive('handle')
+            ->andReturnUsing(function () use ($order) { $order[] = 3; });
+
+        $run->appendHandler($handlerOne);
+        $run->appendHandler($handlerTwo);
+        $run->appendHandler($handlerThree);
+
+        // Get an exception to be handled, and verify that the handlers
+        // are given the handler, and in the right order.
+        $run->handleException($exception);
+        $this->assertEquals([1, 2, 3], $order->getArrayCopy());
+    }
+
+    public function testPrependHandler()
+    {
+        $run       = $this->getRunInstance();
+        $exception = $this->getException();
+        $order     = new ArrayObject();
+
+        $handlerOne   = $this->getHandler();
+        $handlerTwo   = $this->getHandler();
+        $handlerThree = $this->getHandler();
+
+        $handlerOne->shouldReceive('handle')
+            ->andReturnUsing(function () use ($order) { $order[] = 1; });
+        $handlerTwo->shouldReceive('handle')
+            ->andReturnUsing(function () use ($order) { $order[] = 2; });
+        $handlerThree->shouldReceive('handle')
+            ->andReturnUsing(function () use ($order) { $order[] = 3; });
+
+        $run->prependHandler($handlerOne);
+        $run->prependHandler($handlerTwo);
+        $run->prependHandler($handlerThree);
+
+        // Get an exception to be handled, and verify that the handlers
+        // are given the handler, and in the right order.
+        $run->handleException($exception);
+        $this->assertEquals([3, 2, 1], $order->getArrayCopy());
     }
 }


### PR DESCRIPTION
Reverts all changes made to the tests which changes the behaviour (see #630).
Fixed `appendHandler`/`prependHandler` methods to add desired feature and
keep Backward Compatibility.

Adds test to check if behaviour of new methods is right.

Fixes #639

-----
Changes to make in V3 - BC Break:
- `getHandlers` should return handlers in order they are gonna be executed.
- `popHandler` should return the last handler to execute.
- `shiftHandler` should return the first handler to execute.

