### PR TITLE
Fix usage of __METHOD__ inside of closure

### DIFF
--- a/src/Whoops/Exception/FrameCollection.php
+++ b/src/Whoops/Exception/FrameCollection.php
@@ -61,7 +61,7 @@ class FrameCollection implements ArrayAccess, IteratorAggregate, Serializable, C
 
             if (!$frame instanceof Frame) {
                 throw new UnexpectedValueException(
-                    "Callable to " . __METHOD__ . " must return a Frame object"
+                    "Callable to " . __CLASS__ . "::map must return a Frame object"
                 );
             }
 


### PR DESCRIPTION
The value of `__METHOD__` would be a description of the nearest function-like, i.e. `'{closure}'`

This was detected via static analysis (Phan)