### PR TITLE
Fix anonymous class dumping in PrettyPageHandler

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -145,7 +145,7 @@ class PrettyPageHandler extends Handler
             // https://github.com/filp/whoops/pull/404
             $cloner->addCasters(['*' => function ($obj, $a, $stub, $isNested, $filter = 0) {
                 $class = $stub->class;
-                $classes = [$class => $class] + class_parents($class) + class_implements($class);
+                $classes = [$class => $class] + class_parents($obj) + class_implements($obj);
 
                 foreach ($classes as $class) {
                     if (isset(AbstractCloner::$defaultCasters[$class])) {


### PR DESCRIPTION
Fix this warning not to occur when an anonymous class instance is provided.

```
PHP Warning: class_parents(): Class @anonymous does not exist and could not be loaded in {PROJECT_DIR}/vendor/filp/whoops/src/Whoops/Handler/PrettyPageHandler.php on line 148
```

When anonymous class instance, a warning occurs because `$class = '@anonymous'`.