### PR TITLE
PHPDoc fixes

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -29,8 +29,9 @@ class PrettyPageHandler extends Handler
     const EDITOR_XDEBUG = "xdebug";
 
     /**
-     * Search paths to be scanned for resources, in the reverse
-     * order they're declared.
+     * Search paths to be scanned for resources.
+     *
+     * Stored in the reverse order they're declared.
      *
      * @var array
      */
@@ -84,19 +85,22 @@ class PrettyPageHandler extends Handler
     ];
 
     /**
-     * A string identifier for a known IDE/text editor, or a closure
-     * that resolves a string that can be used to open a given file
-     * in an editor. If the string contains the special substrings
-     * %file or %line, they will be replaced with the correct data.
+     * An identifier for a known IDE/text editor.
+     *
+     * Either a string, or a calalble that resolves a string, that can be used
+     * to open a given file in an editor. If the string contains the special
+     * substrings %file or %line, they will be replaced with the correct data.
      *
      * @example
-     *  "txmt://open?url=%file&line=%line"
-     * @var mixed $editor
+     *   "txmt://open?url=%file&line=%line"
+     *
+     * @var callable|string $editor
      */
     protected $editor;
 
     /**
-     * A list of known editor strings
+     * A list of known editor strings.
+     *
      * @var array
      */
     protected $editors = [
@@ -118,6 +122,8 @@ class PrettyPageHandler extends Handler
 
     /**
      * Constructor.
+     *
+     * @return void
      */
     public function __construct()
     {
@@ -271,9 +277,9 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Get the stack trace frames of the exception that is currently being handled.
+     * Get the stack trace frames of the exception currently being handled.
      *
-     * @return \Whoops\Exception\FrameCollection;
+     * @return \Whoops\Exception\FrameCollection
      */
     protected function getExceptionFrames()
     {
@@ -294,7 +300,7 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Get the code of the exception that is currently being handled.
+     * Get the code of the exception currently being handled.
      *
      * @return string
      */
@@ -321,10 +327,14 @@ class PrettyPageHandler extends Handler
 
     /**
      * Adds an entry to the list of tables displayed in the template.
+     *
      * The expected data is a simple associative array. Any nested arrays
-     * will be flattened with print_r
+     * will be flattened with `print_r`.
+     *
      * @param string $label
      * @param array  $data
+     *
+     * @return void
      */
     public function addDataTable($label, array $data)
     {
@@ -333,13 +343,17 @@ class PrettyPageHandler extends Handler
 
     /**
      * Lazily adds an entry to the list of tables displayed in the table.
-     * The supplied callback argument will be called when the error is rendered,
-     * it should produce a simple associative array. Any nested arrays will
-     * be flattened with print_r.
+     *
+     * The supplied callback argument will be called when the error is
+     * rendered, it should produce a simple associative array. Any nested
+     * arrays will be flattened with `print_r`.
+     *
+     * @param string   $label
+     * @param callable $callback Callable returning an associative array
      *
      * @throws InvalidArgumentException If $callback is not callable
-     * @param  string                   $label
-     * @param  callable                 $callback Callable returning an associative array
+     *
+     * @return void
      */
     public function addDataTableCallback($label, /* callable */ $callback)
     {
@@ -362,9 +376,12 @@ class PrettyPageHandler extends Handler
 
     /**
      * Returns all the extra data tables registered with this handler.
-     * Optionally accepts a 'label' parameter, to only return the data
-     * table under that label.
-     * @param  string|null      $label
+     *
+     * Optionally accepts a 'label' parameter, to only return the data table
+     * under that label.
+     *
+     * @param string|null $label
+     *
      * @return array[]|callable
      */
     public function getDataTables($label = null)
@@ -378,10 +395,14 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Allows to disable all attempts to dynamically decide whether to
-     * handle or return prematurely.
-     * Set this to ensure that the handler will perform no matter what.
-     * @param  bool|null $value
+     * Set whether to handle unconditionally. 
+     *
+     * Allows to disable all attempts to dynamically decide whether to handle
+     * or return prematurely. Set this to ensure that the handler will perform,
+     * no matter what.
+     *
+     * @param bool|null $value
+     *
      * @return bool|null
      */
     public function handleUnconditionally($value = null)
@@ -394,10 +415,11 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Adds an editor resolver, identified by a string
-     * name, and that may be a string path, or a callable
-     * resolver. If the callable returns a string, it will
-     * be set as the file reference's href attribute.
+     * Adds an editor resolver.
+     *
+     * Either a string, or a closure that resolves a string, that can be used
+     * to open a given file in an editor. If the string contains the special
+     * substrings %file or %line, they will be replaced with the correct data.
      *
      * @example
      *  $run->addEditor('macvim', "mvim://open?url=file://%file&line=%line")
@@ -406,8 +428,11 @@ class PrettyPageHandler extends Handler
      *       unlink($file);
      *       return "http://stackoverflow.com";
      *   });
-     * @param string $identifier
+     *
+     * @param string          $identifier
      * @param string|callable $resolver
+     *
+     * @return void
      */
     public function addEditor($identifier, $resolver)
     {
@@ -415,18 +440,21 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Set the editor to use to open referenced files, by a string
-     * identifier, or a callable that will be executed for every
-     * file reference, with a $file and $line argument, and should
-     * return a string.
+     * Set the editor to use to open referenced files.
+     *
+     * Pass either the name of a configured editor, or a closure that directly
+     * resolves an editor string.
      *
      * @example
      *   $run->setEditor(function($file, $line) { return "file:///{$file}"; });
      * @example
      *   $run->setEditor('sublime');
      *
+     * @param string|callable $editor
+     *
      * @throws InvalidArgumentException If invalid argument identifier provided
-     * @param  string|callable          $editor
+     *
+     * @return void
      */
     public function setEditor($editor)
     {
@@ -441,14 +469,13 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Given a string file path, and an integer file line,
-     * executes the editor resolver and returns, if available,
-     * a string that may be used as the href property for that
-     * file reference.
+     * Get the editor href for a given file and line, if available.
+     *
+     * @param string $filePath
+     * @param int    $line
      *
      * @throws InvalidArgumentException If editor resolver does not return a string
-     * @param  string                   $filePath
-     * @param  int                      $line
+     *
      * @return string|bool
      */
     public function getEditorHref($filePath, $line)
@@ -474,13 +501,13 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Given a boolean if the editor link should
-     * act as an Ajax request. The editor must be a
-     * valid callable function/closure
+     * Determine if the editor link should act as an Ajax request.
      *
-     * @throws UnexpectedValueException  If editor resolver does not return a boolean
-     * @param  string                   $filePath
-     * @param  int                      $line
+     * @param string  $filePath
+     * @param int     $line
+     *
+     * @throws UnexpectedValueException If editor resolver does not return a boolean
+     *
      * @return bool
      */
     public function getEditorAjax($filePath, $line)
@@ -497,12 +524,11 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Given a boolean if the editor link should
-     * act as an Ajax request. The editor must be a
-     * valid callable function/closure
+     * Determines both the editor and if ajax should be used.
      *
-     * @param  string $filePath
-     * @param  int    $line
+     * @param string $filePath
+     * @param int    $line
+     *
      * @return array
      */
     protected function getEditor($filePath, $line)
@@ -546,7 +572,10 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * @param  string $title
+     * Set the page title.
+     *
+     * @param string $title
+     *
      * @return void
      */
     public function setPageTitle($title)
@@ -555,6 +584,8 @@ class PrettyPageHandler extends Handler
     }
 
     /**
+     * Get the page title.
+     *
      * @return string
      */
     public function getPageTitle()
@@ -563,12 +594,12 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Adds a path to the list of paths to be searched for
-     * resources.
+     * Adds a path to the list of paths to be searched for resources.
+     *
+     * @param  string $path
      *
      * @throws InvalidArgumentException If $path is not a valid directory
      *
-     * @param  string $path
      * @return void
      */
     public function addResourcePath($path)
@@ -585,7 +616,8 @@ class PrettyPageHandler extends Handler
     /**
      * Adds a custom css file to be loaded.
      *
-     * @param  string $name
+     * @param string $name
+     *
      * @return void
      */
     public function addCustomCss($name)
@@ -603,13 +635,15 @@ class PrettyPageHandler extends Handler
 
     /**
      * Finds a resource, by its relative path, in all available search paths.
+     *
      * The search is performed starting at the last search path, and all the
-     * way back to the first, enabling a cascading-type system of overrides
-     * for all resources.
+     * way back to the first, enabling a cascading-type system of overrides for
+     * all resources.
+     *
+     * @param  string $resource
      *
      * @throws RuntimeException If resource cannot be found in any of the available paths
      *
-     * @param  string $resource
      * @return string
      */
     protected function getResource($resource)
@@ -655,7 +689,8 @@ class PrettyPageHandler extends Handler
     /**
      * @deprecated
      *
-     * @param  string $resourcesPath
+     * @param string $resourcesPath
+     *
      * @return void
      */
     public function setResourcesPath($resourcesPath)
@@ -677,6 +712,8 @@ class PrettyPageHandler extends Handler
      * Set the application paths.
      *
      * @param array $applicationPaths
+     *
+     * @return void
      */
     public function setApplicationPaths($applicationPaths)
     {
@@ -687,6 +724,8 @@ class PrettyPageHandler extends Handler
      * Set the application root path.
      *
      * @param string $applicationRootPath
+     *
+     * @return void
      */
     public function setApplicationRootPath($applicationRootPath)
     {
@@ -696,8 +735,10 @@ class PrettyPageHandler extends Handler
     /**
      * blacklist a sensitive value within one of the superglobal arrays.
      *
-     * @param $superGlobalName string the name of the superglobal array, e.g. '_GET'
-     * @param $key string the key within the superglobal
+     * @param string $superGlobalName The name of the superglobal array, e.g. '_GET'
+     * @param string $key             The key within the superglobal
+     *
+     * @return void
      */
     public function blacklist($superGlobalName, $key)
     {
@@ -706,12 +747,14 @@ class PrettyPageHandler extends Handler
 
     /**
      * Checks all values within the given superGlobal array.
-     * Blacklisted values will be replaced by a equal length string cointaining only '*' characters.
      *
-     * We intentionally dont rely on $GLOBALS as it depends on 'auto_globals_jit' php.ini setting.
+     * Blacklisted values will be replaced by a equal length string cointaining
+     * only '*' characters. We intentionally dont rely on $GLOBALS as it
+     * depends on the 'auto_globals_jit' php.ini setting.
      *
-     * @param $superGlobal array One of the superglobal arrays
-     * @param $superGlobalName string the name of the superglobal array, e.g. '_GET'
+     * @param array $superGlobal      One of the superglobal arrays
+     * @param string $superGlobalName The name of the superglobal array, e.g. '_GET'
+     *
      * @return array $values without sensitive data
      */
     private function masked(array $superGlobal, $superGlobalName)
@@ -719,11 +762,13 @@ class PrettyPageHandler extends Handler
         $blacklisted = $this->blacklist[$superGlobalName];
 
         $values = $superGlobal;
+
         foreach ($blacklisted as $key) {
             if (isset($superGlobal[$key]) && is_string($superGlobal[$key])) {
                 $values[$key] = str_repeat('*', strlen($superGlobal[$key]));
             }
         }
+
         return $values;
     }
 }


### PR DESCRIPTION
Short descriptions should be at most 80 characters (counting from the far left, so actually 74 max of text). There then should be a blank phpdoc line then optional 80 character wrapped additional descriptions, then param docs, then throws docs, then return docs.