### PR TITLE
set  protected

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -118,7 +118,7 @@ class PrettyPageHandler extends Handler
     /**
      * @var TemplateHelper
      */
-    private $templateHelper;
+    protected $templateHelper;
 
     /**
      * Constructor.
@@ -395,7 +395,7 @@ class PrettyPageHandler extends Handler
     }
 
     /**
-     * Set whether to handle unconditionally. 
+     * Set whether to handle unconditionally.
      *
      * Allows to disable all attempts to dynamically decide whether to handle
      * or return prematurely. Set this to ensure that the handler will perform,


### PR DESCRIPTION
I change private property to protected, to give possibility to extend PrettyPageHandler and use own templateHelper. 

This is usefull in case you wont force PrettyPageHandler to dump arguments in function call. For details see issue https://github.com/filp/whoops/issues/642
