### PR TITLE
Check exists xdebug_is_enabled

### DIFF
--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -251,7 +251,7 @@ class Inspector
             return $traces;
         }
 
-        if (!extension_loaded('xdebug') || !xdebug_is_enabled()) {
+        if (!extension_loaded('xdebug') || !function_exists('xdebug_is_enabled') || !xdebug_is_enabled()) {
             return $traces;
         }
 


### PR DESCRIPTION
Ubuntu 20.04
PHP 8.0 RC3
php8.0-xdebug (2.9.8+2.8.1+2.5.5+3.0.0~beta1-2+ubuntu20.04.1+deb.sury.org+1)
extension_loaded('xdebug') -> true
xdebug_is_enabled -> function does not exist

![screen](https://user-images.githubusercontent.com/826831/97793480-662f8c00-1bfd-11eb-8e0a-ab3273f749b2.png)
