### PR TITLE
Fix styles of copy button after hover

### DIFF
--- a/src/Whoops/Resources/js/whoops.base.js
+++ b/src/Whoops/Resources/js/whoops.base.js
@@ -100,7 +100,7 @@ Zepto(function($) {
 
   var clipboard = new Clipboard('.clipboard');
   var showTooltip = function(elem, msg) {
-    elem.setAttribute('class', 'clipboard tooltipped tooltipped-s');
+    elem.classList.add('tooltipped', 'tooltipped-s');
     elem.setAttribute('aria-label', msg);
   };
 
@@ -117,7 +117,7 @@ Zepto(function($) {
   var btn = document.querySelector('.clipboard');
 
   btn.addEventListener('mouseleave', function(e) {
-    e.currentTarget.setAttribute('class', 'rightButton clipboard');
+    e.currentTarget.classList.remove('tooltipped', 'tooltipped-s');
     e.currentTarget.removeAttribute('aria-label');
   });
 


### PR DESCRIPTION
since https://github.com/filp/whoops/pull/579 the styles of the copy button are set via the class `rightButton` instead of the previous id `#copy-button`.
But on mouseleave the class is set to `clipboard` and the `rightButton` class is missing.

Original button:
<img width="68" alt="Bildschirmfoto 2021-01-21 um 22 12 06" src="https://user-images.githubusercontent.com/330436/105413042-d4e91800-5c35-11eb-9b5f-971fb1e4c522.png">

Wrong style after hovering:
<img width="64" alt="Bildschirmfoto 2021-01-21 um 22 12 19" src="https://user-images.githubusercontent.com/330436/105413074-e03c4380-5c35-11eb-9c2e-7c0af49c3bd1.png">
