### PR TITLE
Builder-style handlers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
             "role": "Developer"
         }
     ],
+    "scripts": {
+        "test": "phpunit --testdox tests"
+    },
     "require": {
         "php": "^5.5.9 || ^7.0 || ^8.0",
         "psr/log": "^1.0.1"        

--- a/src/Whoops/Handler/JsonResponseHandler.php
+++ b/src/Whoops/Handler/JsonResponseHandler.php
@@ -28,7 +28,7 @@ class JsonResponseHandler extends Handler
     /**
      * Returns errors[[]] instead of error[] to be in compliance with the json:api spec
      * @param bool $jsonApi Default is false
-     * @return $this
+     * @return static
      */
     public function setJsonApi($jsonApi = false)
     {
@@ -38,7 +38,7 @@ class JsonResponseHandler extends Handler
 
     /**
      * @param  bool|null  $returnFrames
-     * @return bool|$this
+     * @return bool|static
      */
     public function addTraceToOutput($returnFrames = null)
     {

--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -108,7 +108,7 @@ class PlainTextHandler extends Handler
     /**
      * Add error trace to output.
      * @param  bool|null  $addTraceToOutput
-     * @return bool|$this
+     * @return bool|static
      */
     public function addTraceToOutput($addTraceToOutput = null)
     {
@@ -123,7 +123,7 @@ class PlainTextHandler extends Handler
     /**
      * Add previous exceptions to output.
      * @param  bool|null $addPreviousToOutput
-     * @return bool|$this
+     * @return bool|static
      */
     public function addPreviousToOutput($addPreviousToOutput = null)
     {

--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -97,11 +97,12 @@ class PlainTextHandler extends Handler
      * Set var dumper callback function.
      *
      * @param  callable $dumper
-     * @return void
+     * @return static
      */
     public function setDumper(callable $dumper)
     {
         $this->dumper = $dumper;
+        return $this;
     }
 
     /**
@@ -138,7 +139,7 @@ class PlainTextHandler extends Handler
      * Add error trace function arguments to output.
      * Set to True for all frame args, or integer for the n first frame args.
      * @param  bool|integer|null $addTraceFunctionArgsToOutput
-     * @return null|bool|integer
+     * @return static|bool|integer
      */
     public function addTraceFunctionArgsToOutput($addTraceFunctionArgsToOutput = null)
     {
@@ -151,6 +152,7 @@ class PlainTextHandler extends Handler
         } else {
             $this->addTraceFunctionArgsToOutput = $addTraceFunctionArgsToOutput;
         }
+        return $this;
     }
 
     /**
@@ -158,10 +160,12 @@ class PlainTextHandler extends Handler
      * If the limit is reached, the var_dump output is discarded.
      * Prevent memory limit errors.
      * @var integer
+     * @return static
      */
     public function setTraceFunctionArgsOutputLimit($traceFunctionArgsOutputLimit)
     {
         $this->traceFunctionArgsOutputLimit = (integer) $traceFunctionArgsOutputLimit;
+        return $this;
     }
 
     /**
@@ -199,7 +203,7 @@ class PlainTextHandler extends Handler
     /**
      * Only output to logger.
      * @param  bool|null $loggerOnly
-     * @return null|bool
+     * @return static|bool
      */
     public function loggerOnly($loggerOnly = null)
     {
@@ -208,6 +212,7 @@ class PlainTextHandler extends Handler
         }
 
         $this->loggerOnly = (bool) $loggerOnly;
+        return $this;
     }
 
     /**

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -349,11 +349,12 @@ class PrettyPageHandler extends Handler
      * @param string $label
      * @param array  $data
      *
-     * @return void
+     * @return static
      */
     public function addDataTable($label, array $data)
     {
         $this->extraTables[$label] = $data;
+        return $this;
     }
 
     /**
@@ -368,7 +369,7 @@ class PrettyPageHandler extends Handler
      *
      * @throws InvalidArgumentException If $callback is not callable
      *
-     * @return void
+     * @return static
      */
     public function addDataTableCallback($label, /* callable */ $callback)
     {
@@ -387,6 +388,8 @@ class PrettyPageHandler extends Handler
                 return [];
             }
         };
+
+        return $this;
     }
 
     /**
@@ -418,7 +421,7 @@ class PrettyPageHandler extends Handler
      *
      * @param bool|null $value
      *
-     * @return bool|null
+     * @return bool|static
      */
     public function handleUnconditionally($value = null)
     {
@@ -427,6 +430,7 @@ class PrettyPageHandler extends Handler
         }
 
         $this->handleUnconditionally = (bool) $value;
+        return $this;
     }
 
     /**
@@ -447,11 +451,12 @@ class PrettyPageHandler extends Handler
      * @param string          $identifier
      * @param string|callable $resolver
      *
-     * @return void
+     * @return static
      */
     public function addEditor($identifier, $resolver)
     {
         $this->editors[$identifier] = $resolver;
+        return $this;
     }
 
     /**
@@ -469,7 +474,7 @@ class PrettyPageHandler extends Handler
      *
      * @throws InvalidArgumentException If invalid argument identifier provided
      *
-     * @return void
+     * @return static
      */
     public function setEditor($editor)
     {
@@ -481,6 +486,7 @@ class PrettyPageHandler extends Handler
         }
 
         $this->editor = $editor;
+        return $this;
     }
 
     /**
@@ -591,11 +597,12 @@ class PrettyPageHandler extends Handler
      *
      * @param string $title
      *
-     * @return void
+     * @return static
      */
     public function setPageTitle($title)
     {
         $this->pageTitle = (string) $title;
+        return $this;
     }
 
     /**
@@ -615,7 +622,7 @@ class PrettyPageHandler extends Handler
      *
      * @throws InvalidArgumentException If $path is not a valid directory
      *
-     * @return void
+     * @return static
      */
     public function addResourcePath($path)
     {
@@ -626,6 +633,7 @@ class PrettyPageHandler extends Handler
         }
 
         array_unshift($this->searchPaths, $path);
+        return $this;
     }
 
     /**
@@ -633,11 +641,12 @@ class PrettyPageHandler extends Handler
      *
      * @param string|null $name
      *
-     * @return void
+     * @return static
      */
     public function addCustomCss($name)
     {
         $this->customCss = $name;
+        return $this;
     }
 
     /**
@@ -645,11 +654,12 @@ class PrettyPageHandler extends Handler
      *
      * @param string|null $name
      *
-     * @return void
+     * @return static
      */
     public function addCustomJs($name)
     {
         $this->customJs = $name;
+        return $this;
     }
 
     /**
@@ -718,11 +728,12 @@ class PrettyPageHandler extends Handler
      *
      * @param string $resourcesPath
      *
-     * @return void
+     * @return static
      */
     public function setResourcesPath($resourcesPath)
     {
         $this->addResourcePath($resourcesPath);
+        return $this;
     }
 
     /**
@@ -767,11 +778,12 @@ class PrettyPageHandler extends Handler
      * @param string $key             The key within the superglobal
      * @see hideSuperglobalKey
      *
-     * @return void
+     * @return static
      */
     public function blacklist($superGlobalName, $key)
     {
         $this->blacklist[$superGlobalName][] = $key;
+        return $this;
     }
 
     /**
@@ -779,7 +791,7 @@ class PrettyPageHandler extends Handler
      *
      * @param string $superGlobalName The name of the superglobal array, e.g. '_GET'
      * @param string $key             The key within the superglobal
-     * @return void
+     * @return static
      */
     public function hideSuperglobalKey($superGlobalName, $key)
     {

--- a/src/Whoops/Handler/XmlResponseHandler.php
+++ b/src/Whoops/Handler/XmlResponseHandler.php
@@ -23,7 +23,7 @@ class XmlResponseHandler extends Handler
 
     /**
      * @param  bool|null  $returnFrames
-     * @return bool|$this
+     * @return bool|static
      */
     public function addTraceToOutput($returnFrames = null)
     {

--- a/tests/Whoops/Handler/PlainTextHandlerTest.php
+++ b/tests/Whoops/Handler/PlainTextHandlerTest.php
@@ -63,7 +63,7 @@ class PlainTextHandlerTest extends TestCase
         $run->register();
 
         $exception = $exception ?: $this->getException();
-        
+
         try {
             ob_start();
             $run->handleException($exception);
@@ -100,7 +100,7 @@ class PlainTextHandlerTest extends TestCase
     {
         $handler = $this->getHandler();
 
-        $handler->addTraceToOutput(true);
+        $this->assertEquals($handler, $handler->addTraceToOutput(true));
         $this->assertTrue($handler->addTraceToOutput());
 
         $handler->addTraceToOutput(false);
@@ -129,7 +129,7 @@ class PlainTextHandlerTest extends TestCase
     {
         $handler = $this->getHandler();
 
-        $handler->addTraceFunctionArgsToOutput(true);
+        $this->assertEquals($handler, $handler->addTraceFunctionArgsToOutput(true));
         $this->assertTrue($handler->addTraceFunctionArgsToOutput());
 
         $handler->addTraceFunctionArgsToOutput(false);
@@ -178,7 +178,7 @@ class PlainTextHandlerTest extends TestCase
     {
         $handler = $this->getHandler();
 
-        $handler->loggerOnly(true);
+        $this->assertEquals($handler, $handler->loggerOnly(true));
         $this->assertTrue($handler->loggerOnly());
 
         $handler->loggerOnly(false);

--- a/tests/Whoops/Handler/PrettyPageHandlerTest.php
+++ b/tests/Whoops/Handler/PrettyPageHandlerTest.php
@@ -58,7 +58,7 @@ class PrettyPageHandlerTest extends TestCase
     {
         $title = 'My Cool Error Handler';
         $handler = $this->getHandler();
-        $handler->setPageTitle($title);
+        $this->assertEquals($handler, $handler->setPageTitle($title));
 
         $this->assertEquals($title, $handler->getPagetitle());
     }
@@ -72,7 +72,7 @@ class PrettyPageHandlerTest extends TestCase
         $path = __DIR__; // guaranteed to be valid!
         $handler = $this->getHandler();
 
-        $handler->addResourcePath($path);
+        $this->assertEquals($handler, $handler->addResourcePath($path));
         $allPaths = $handler->getResourcePaths();
 
         $this->assertCount(2, $allPaths);
@@ -110,8 +110,8 @@ class PrettyPageHandlerTest extends TestCase
             'time'  => time(),
         ];
 
-        $handler->addDataTable('table 1', $tableOne);
-        $handler->addDataTable('table 2', $tableTwo);
+        $this->assertEquals($handler, $handler->addDataTable('table 1', $tableOne));
+        $this->assertEquals($handler, $handler->addDataTable('table 2', $tableTwo));
 
         // should contain both tables:
         $tables = $handler->getDataTables();
@@ -178,10 +178,10 @@ class PrettyPageHandlerTest extends TestCase
         $this->assertSame($expected3, $table3());
         $this->assertSame($expected4, $table4($inspectorForTable4));
 
-        $handler->addDataTableCallback('table1', $table1);
-        $handler->addDataTableCallback('table2', $table2);
-        $handler->addDataTableCallback('table3', $table3);
-        $handler->addDataTableCallback('table4', $table4);
+        $this->assertEquals($handler, $handler->addDataTableCallback('table1', $table1));
+        $this->assertEquals($handler, $handler->addDataTableCallback('table2', $table2));
+        $this->assertEquals($handler, $handler->addDataTableCallback('table3', $table3));
+        $this->assertEquals($handler, $handler->addDataTableCallback('table4', $table4));
 
         $tables = $handler->getDataTables();
         $this->assertCount(4, $tables);
@@ -209,7 +209,7 @@ class PrettyPageHandlerTest extends TestCase
     public function testSetEditorSimple()
     {
         $handler = $this->getHandler();
-        $handler->setEditor('sublime');
+        $this->assertEquals($handler, $handler->setEditor('sublime'));
 
         $this->assertEquals(
             $handler->getEditorHref('/foo/bar.php', 10),
@@ -237,11 +237,11 @@ class PrettyPageHandlerTest extends TestCase
         $handler = $this->getHandler();
 
         // Test Callable editor with String return
-        $handler->setEditor(function ($file, $line) {
+        $this->assertEquals($handler, $handler->setEditor(function ($file, $line) {
             $file = rawurlencode($file);
             $line = rawurlencode($line);
             return "http://google.com/search/?q=$file:$line";
-        });
+        }));
 
         $this->assertEquals(
             $handler->getEditorHref('/foo/bar.php', 10),
@@ -249,14 +249,14 @@ class PrettyPageHandlerTest extends TestCase
         );
 
         // Then test Callable editor with Array return
-        $handler->setEditor(function ($file, $line) {
+        $this->assertEquals($handler, $handler->setEditor(function ($file, $line) {
             $file = rawurlencode($file);
             $line = rawurlencode($line);
             return [
                 'url' => "http://google.com/search/?q=$file:$line",
                 'ajax' => true,
             ];
-        });
+        }));
 
         $this->assertEquals(
             $handler->getEditorHref('/foo/bar.php', 10),
@@ -269,14 +269,14 @@ class PrettyPageHandlerTest extends TestCase
         );
 
 
-        $handler->setEditor(function ($file, $line) {
+        $this->assertEquals($handler, $handler->setEditor(function ($file, $line) {
             $file = rawurlencode($file);
             $line = rawurlencode($line);
             return [
                 'url' => "http://google.com/search/?q=$file:$line",
                 'ajax' => false,
             ];
-        });
+        }));
 
         $this->assertEquals(
             $handler->getEditorHref('/foo/bar.php', 10),
@@ -288,9 +288,9 @@ class PrettyPageHandlerTest extends TestCase
             false
         );
 
-        $handler->setEditor(function ($file, $line) {
+        $this->assertEquals($handler, $handler->setEditor(function ($file, $line) {
             return false;
-        });
+        }));
 
         $this->assertEquals(
             $handler->getEditorHref('/foo/bar.php', 10),
@@ -306,11 +306,12 @@ class PrettyPageHandlerTest extends TestCase
     public function testAddEditor()
     {
         $handler = $this->getHandler();
-        $handler->addEditor('test-editor', function ($file, $line) {
+        $this->assertEquals($handler, $handler->addEditor('test-editor',
+                function ($file, $line) {
             return "cool beans $file:$line";
-        });
+        }));
 
-        $handler->setEditor('test-editor');
+        $this->assertEquals($handler, $handler->setEditor('test-editor'));
 
         $this->assertEquals(
             $handler->getEditorHref('hello', 20),
@@ -332,7 +333,7 @@ class PrettyPageHandlerTest extends TestCase
         ini_set('xdebug.file_link_format', '%f:%l');
 
         $handler = $this->getHandler();
-        $handler->setEditor('xdebug');
+        $this->assertEquals($handler, $handler->setEditor('xdebug'));
 
         $this->assertEquals(
             '/foo/bar.php:10',


### PR DESCRIPTION
All add/set methods now self-return so handlers can be configured inline.

Particularly troublesome for PrettyPageHandler. It seems JsonPageHandler was already doing this for it's methods (`setJsonApi()`, `addTraceToOutput()`).

Like this:
```php
$run->addHandler((new PrettyPageHandler)
   ->setEditor('vscode')
   ->setPageTitle('An error occurred!')
   ->hideSuperglobalKey('_SERVER', 'SECURITY_KEY'));
```
