### PR TITLE
PrettyPageHandler allow hiding super globals with non-string value

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -175,6 +175,8 @@ class PrettyPageHandler extends Handler
 
     /**
      * @return int|null
+     *
+     * @throws \Exception
      */
     public function handle()
     {
@@ -801,9 +803,10 @@ class PrettyPageHandler extends Handler
     /**
      * Checks all values within the given superGlobal array.
      *
-     * Blacklisted values will be replaced by a equal length string cointaining
-     * only '*' characters. We intentionally dont rely on $GLOBALS as it
-     * depends on the 'auto_globals_jit' php.ini setting.
+     * Blacklisted values will be replaced by a equal length string containing
+     * only '*' characters for string values.
+     * Non-string values will be replaced with a fixed asterisk count.
+     * We intentionally dont rely on $GLOBALS as it depends on the 'auto_globals_jit' php.ini setting.
      *
      * @param array  $superGlobal     One of the superglobal arrays
      * @param string $superGlobalName The name of the superglobal array, e.g. '_GET'
@@ -817,8 +820,8 @@ class PrettyPageHandler extends Handler
         $values = $superGlobal;
 
         foreach ($blacklisted as $key) {
-            if (isset($superGlobal[$key]) && is_string($superGlobal[$key])) {
-                $values[$key] = str_repeat('*', strlen($superGlobal[$key]));
+            if (isset($superGlobal[$key])) {
+                $values[$key] = str_repeat('*', is_string($superGlobal[$key]) ? strlen($superGlobal[$key]) : 3);
             }
         }
 


### PR DESCRIPTION
- Enhance PrettyPageHandler to allow hiding super globals with non-string value. (non-string values will have a fixed asterisk length of 3)
- Fix missing @throws annotation.
- Fix typo in doc-block
- Add new string/non-string behaviour to doc-block description.

Fixes #690