### PR TITLE
Avoid redirects away from error page

### DIFF
--- a/src/Whoops/Util/SystemFacade.php
+++ b/src/Whoops/Util/SystemFacade.php
@@ -124,6 +124,13 @@ class SystemFacade
      */
     public function setHttpResponseCode($httpCode)
     {
+        if (!headers_sent()) {
+            // Ensure that no 'location' header is present as otherwise this
+            // will override the HTTP code being set here, and mask the
+            // expected error page.
+            header_remove('location');
+        }
+
         return http_response_code($httpCode);
     }
 

--- a/tests/Whoops/Util/SystemFacadeTest.php
+++ b/tests/Whoops/Util/SystemFacadeTest.php
@@ -137,6 +137,14 @@ class SystemFacadeTest extends TestCase
 
         $this->facade->setHttpResponseCode(230);
     }
+
+    public function test_it_removes_any_location_header_already_sent()
+    {
+        self::$runtime->shouldReceive('headers_sent')->once()->withNoArgs();
+        self::$runtime->shouldReceive('header_remove')->once()->with('location');
+
+        $this->facade->setHttpResponseCode(204);
+    }
 }
 
 function ob_start()
@@ -201,6 +209,16 @@ function error_reporting($level = null)
 function error_get_last()
 {
     return SystemFacadeTest::delegate('error_get_last', func_get_args());
+}
+
+function header_remove($header = null)
+{
+    return SystemFacadeTest::delegate('header_remove', func_get_args());
+}
+
+function headers_sent(&$filename = null, &$line = null)
+{
+    return SystemFacadeTest::delegate('headers_sent', func_get_args());
 }
 
 function http_response_code($code = null)

--- a/tests/Whoops/Util/SystemFacadeTest.php
+++ b/tests/Whoops/Util/SystemFacadeTest.php
@@ -133,17 +133,11 @@ class SystemFacadeTest extends TestCase
 
     public function test_it_delegates_sending_an_http_response_code_to_the_native_implementation()
     {
+        self::$runtime->shouldReceive('headers_sent')->once()->withNoArgs();
+        self::$runtime->shouldReceive('header_remove')->once()->with('location');
         self::$runtime->shouldReceive('http_response_code')->once()->with(230);
 
         $this->facade->setHttpResponseCode(230);
-    }
-
-    public function test_it_removes_any_location_header_already_sent()
-    {
-        self::$runtime->shouldReceive('headers_sent')->once()->withNoArgs();
-        self::$runtime->shouldReceive('header_remove')->once()->with('location');
-
-        $this->facade->setHttpResponseCode(204);
     }
 }
 


### PR DESCRIPTION
When a `location` header is set but no suitable HTTP response code accompanies this (eg, 201, 202, 301, 302, 303, 307, 308), [PHP will send a response code of `302`](https://www.php.net/manual/function.header.php). This will override any (incompatible) response codes set with `http_response_code()`.

With Whoops handling an error after something has set a `location` header, the error page isn't visible in the browser because of this feature. This pull request fixes this masking by removing any `location` headers before setting a suitable HTTP response code.