### PR TITLE
Use netbeans editor without xdebug extension

### DIFF
--- a/docs/Open Files In An Editor.md
+++ b/docs/Open Files In An Editor.md
@@ -25,6 +25,7 @@ The following editors are currently supported by default.
 - `vscode`   - VSCode (ref [Opening VS Code with URLs](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls))
 - `atom`     - Atom (ref [Add core URI handlers](https://github.com/atom/atom/pull/15935))
 - `espresso` - Espresso
+- `netbeans` - Netbeans (ref [xdebug.file_link_format](http://xdebug.org/docs/all_settings#file_link_format))
 
 Adding your own editor is simple:
 

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -27,6 +27,7 @@ class PrettyPageHandler extends Handler
     const EDITOR_ATOM = "atom";
     const EDITOR_ESPRESSO = "espresso";
     const EDITOR_XDEBUG = "xdebug";
+    const EDITOR_NETBEANS = "netbeans";
 
     /**
      * Search paths to be scanned for resources.
@@ -120,6 +121,7 @@ class PrettyPageHandler extends Handler
         "vscode"   => "vscode://file/%file:%line",
         "atom"     => "atom://core/open/file?filename=%file&line=%line",
         "espresso" => "x-espresso://open?filepath=%file&lines=%line",
+        "netbeans" => "netbeans://open/?f=%file:%line",
     ];
 
     /**


### PR DESCRIPTION
According [xdebug.file_link_format](https://xdebug.org/docs/all_settings#file_link_format) the template is `netbeans://open/?f=%file:%line`