### PR TITLE
xdebug.file_link_format template by default without xdebug extension loaded

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -136,10 +136,10 @@ class PrettyPageHandler extends Handler
      */
     public function __construct()
     {
-        if (ini_get('xdebug.file_link_format') || extension_loaded('xdebug')) {
+        if (ini_get('xdebug.file_link_format') || get_cfg_var('xdebug.file_link_format')) {
             // Register editor using xdebug's file_link_format option.
             $this->editors['xdebug'] = function ($file, $line) {
-                return str_replace(['%f', '%l'], [$file, $line], ini_get('xdebug.file_link_format'));
+                return str_replace(['%f', '%l'], [$file, $line], ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format'));
             };
 
             // If xdebug is available, use it as default editor.


### PR DESCRIPTION
When xdebug is not enabled but the propertie `xdebug.file_link_format ` exists, set xdebug by default as editor
based on [Symfony HtmlErrorRenderer](https://github.com/symfony/error-handler/blob/0e6768b8c0dcef26df087df2bbbaa143867a59b2/ErrorRenderer/HtmlErrorRenderer.php#L62)

https://github.com/symfony/error-handler/blob/0e6768b8c0dcef26df087df2bbbaa143867a59b2/ErrorRenderer/HtmlErrorRenderer.php#L61-L63