### PR TITLE
Add types that appendHandler & prependHandler functions can take

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -501,7 +501,7 @@ final class Run implements RunInterface
     /**
      * Resolves the giving handler.
      *
-     * @param Callable|HandlerInterface $handler
+     * @param callable|HandlerInterface $handler
      *
      * @return HandlerInterface
      *

--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -74,7 +74,7 @@ final class Run implements RunInterface
     /**
      * Explicitly request your handler runs as the last of all currently registered handlers.
      *
-     * @param HandlerInterface $handler
+     * @param Callable|HandlerInterface $handler
      *
      * @return Run
      */
@@ -87,7 +87,7 @@ final class Run implements RunInterface
     /**
      * Explicitly request your handler runs as the first of all currently registered handlers.
      *
-     * @param HandlerInterface $handler
+     * @param Callable|HandlerInterface $handler
      *
      * @return Run
      */

--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -74,7 +74,7 @@ final class Run implements RunInterface
     /**
      * Explicitly request your handler runs as the last of all currently registered handlers.
      *
-     * @param Callable|HandlerInterface $handler
+     * @param callable|HandlerInterface $handler
      *
      * @return Run
      */
@@ -87,7 +87,7 @@ final class Run implements RunInterface
     /**
      * Explicitly request your handler runs as the first of all currently registered handlers.
      *
-     * @param Callable|HandlerInterface $handler
+     * @param callable|HandlerInterface $handler
      *
      * @return Run
      */
@@ -100,7 +100,7 @@ final class Run implements RunInterface
      * Register your handler as the last of all currently registered handlers (to be executed first).
      * Prefer using appendHandler and prependHandler for clarity.
      *
-     * @param Callable|HandlerInterface $handler
+     * @param callable|HandlerInterface $handler
      *
      * @return Run
      *

--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -501,7 +501,7 @@ final class Run implements RunInterface
     /**
      * Resolves the giving handler.
      *
-     * @param HandlerInterface $handler
+     * @param Callable|HandlerInterface $handler
      *
      * @return HandlerInterface
      *


### PR DESCRIPTION
Thank you for maintaining the library!

I noticed that `Callable` cannot be passed as an argument to `appendHandler` and `prepandHandler` in `Run.php`

https://github.com/filp/whoops/blob/fdf92f03e150ed84d5967a833ae93abffac0315b/src/Whoops/Run.php#L74-L81
https://github.com/filp/whoops/blob/fdf92f03e150ed84d5967a833ae93abffac0315b/src/Whoops/Run.php#L87-L94

`pushHandler`, which recommends the use of these functions, allows you to pass a `Callable` as an argument

I apologize if this is intentional.