### PR TITLE
Make Frame compatible with PHP 8.1

### DIFF
--- a/src/Whoops/Exception/Frame.php
+++ b/src/Whoops/Exception/Frame.php
@@ -233,12 +233,7 @@ class Frame implements Serializable
      */
     public function serialize()
     {
-        $frame = $this->frame;
-        if (!empty($this->comments)) {
-            $frame['_comments'] = $this->comments;
-        }
-
-        return serialize($frame);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -250,8 +245,21 @@ class Frame implements Serializable
      */
     public function unserialize($serializedFrame)
     {
-        $frame = unserialize($serializedFrame);
+        $this->__unserialize(unserialize($serializedFrame));
+    }
 
+    public function __serialize(): array
+    {
+        $frame = $this->frame;
+        if (!empty($this->comments)) {
+            $frame['_comments'] = $this->comments;
+        }
+
+        return $frame;
+    }
+
+    public function __unserialize(array $frame): void
+    {
         if (!empty($frame['_comments'])) {
             $this->comments = $frame['_comments'];
             unset($frame['_comments']);


### PR DESCRIPTION
Fix the PHP 8.1 warning:
```
Whoops\Exception\Frame implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
```