### PR TITLE
masked support ArrayAccess

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -812,12 +812,12 @@ class PrettyPageHandler extends Handler
      * Non-string values will be replaced with a fixed asterisk count.
      * We intentionally dont rely on $GLOBALS as it depends on the 'auto_globals_jit' php.ini setting.
      *
-     * @param array  $superGlobal     One of the superglobal arrays
+     * @param array|\ArrayAccess  $superGlobal     One of the superglobal arrays
      * @param string $superGlobalName The name of the superglobal array, e.g. '_GET'
      *
      * @return array $values without sensitive data
      */
-    private function masked(array $superGlobal, $superGlobalName)
+    private function masked($superGlobal, $superGlobalName)
     {
         $blacklisted = $this->blacklist[$superGlobalName];
 


### PR DESCRIPTION
```
        $_COOKIE = make(Proxy\Cookie::class);
        $_FILES = make(Proxy\File::class);
        $_GET = make(Proxy\Get::class);
        $_POST = make(Proxy\Post::class);
        $_REQUEST = make(Proxy\Request::class);
        $_SERVER = make(Proxy\Server::class, [$_SERVER]);
       ...
```

### $_COOKIE implements ArrayAccess

`masked`
i want to remove the restrictions