### PR TITLE
Short scalar cast

### DIFF
--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -164,7 +164,7 @@ class PlainTextHandler extends Handler
      */
     public function setTraceFunctionArgsOutputLimit($traceFunctionArgsOutputLimit)
     {
-        $this->traceFunctionArgsOutputLimit = (integer) $traceFunctionArgsOutputLimit;
+        $this->traceFunctionArgsOutputLimit = (int) $traceFunctionArgsOutputLimit;
         return $this;
     }
 


### PR DESCRIPTION
Cast (boolean) and (integer) should be written as (bool) and (int), (double) and (real) as (float), (binary) as (string).