### PR TITLE
Get class to class keyword

### DIFF
--- a/src/Whoops/Exception/Formatter.php
+++ b/src/Whoops/Exception/Formatter.php
@@ -19,7 +19,7 @@ class Formatter
     {
         $exception = $inspector->getException();
         $response = [
-            'type'    => get_class($exception),
+            'type'    => $exception::class,
             'message' => $exception->getMessage(),
             'code'    => $exception->getCode(),
             'file'    => $exception->getFile(),

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -274,7 +274,7 @@ class Inspector
         return [
             'file'  => $exception->getFile(),
             'line'  => $exception->getLine(),
-            'class' => get_class($exception),
+            'class' => $exception::class,
             'args'  => [
                 $exception->getMessage(),
             ],

--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -78,7 +78,7 @@ class PlainTextHandler extends Handler
             throw new InvalidArgumentException(
                 'Argument to ' . __METHOD__ .
                 " must be a valid Logger Interface (aka. Monolog), " .
-                get_class($logger) . ' given.'
+                $logger::class . ' given.'
             );
         }
 
@@ -322,7 +322,7 @@ class PlainTextHandler extends Handler
     {
         return sprintf(
             "%s: %s in file %s on line %d",
-            get_class($exception),
+            $exception::class,
             $exception->getMessage(),
             $exception->getFile(),
             $exception->getLine()

--- a/src/Whoops/Resources/views/env_details.html.php
+++ b/src/Whoops/Resources/views/env_details.html.php
@@ -34,7 +34,7 @@
     <label>Registered Handlers</label>
     <?php foreach ($handlers as $i => $h): ?>
       <div class="handler <?php echo ($h === $handler) ? 'active' : ''?>">
-        <?php echo $i ?>. <?php echo $tpl->escape(get_class($h)) ?>
+        <?php echo $i ?>. <?php echo $tpl->escape($h::class) ?>
       </div>
     <?php endforeach ?>
   </div>


### PR DESCRIPTION
Replace get_class calls on object variables with class keyword syntax.