### PR TITLE
Use arrow functions

### DIFF
--- a/src/Whoops/Exception/Frame.php
+++ b/src/Whoops/Exception/Frame.php
@@ -161,9 +161,7 @@ class Frame implements Serializable
         $comments = $this->comments;
 
         if ($filter !== null) {
-            $comments = array_filter($comments, function ($c) use ($filter) {
-                return $c['context'] == $filter;
-            });
+            $comments = array_filter($comments, fn ($c) => $c['context'] == $filter);
         }
 
         return $comments;

--- a/src/Whoops/Exception/FrameCollection.php
+++ b/src/Whoops/Exception/FrameCollection.php
@@ -30,9 +30,7 @@ class FrameCollection implements ArrayAccess, IteratorAggregate, Serializable, C
      */
     public function __construct(array $frames)
     {
-        $this->frames = array_map(function ($frame) {
-            return new Frame($frame);
-        }, $frames);
+        $this->frames = array_map(fn ($frame) => new Frame($frame), $frames);
     }
 
     /**
@@ -153,9 +151,7 @@ class FrameCollection implements ArrayAccess, IteratorAggregate, Serializable, C
      */
     public function countIsApplication()
     {
-        return count(array_filter($this->frames, function (Frame $f) {
-            return $f->isApplication();
-        }));
+        return count(array_filter($this->frames, fn (Frame $f) => $f->isApplication()));
     }
 
     /**

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -138,9 +138,7 @@ class PrettyPageHandler extends Handler
     {
         if (ini_get('xdebug.file_link_format') || get_cfg_var('xdebug.file_link_format')) {
             // Register editor using xdebug's file_link_format option.
-            $this->editors['xdebug'] = function ($file, $line) {
-                return str_replace(['%f', '%l'], [$file, $line], ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format'));
-            };
+            $this->editors['xdebug'] = fn ($file, $line) => str_replace(['%f', '%l'], [$file, $line], ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format'));
 
             // If xdebug is available, use it as default editor.
             $this->setEditor('xdebug');
@@ -281,9 +279,7 @@ class PrettyPageHandler extends Handler
 
         // Add extra entries list of data tables:
         // @todo: Consolidate addDataTable and addDataTableCallback
-        $extraTables = array_map(function ($table) use ($inspector) {
-            return $table instanceof \Closure ? $table($inspector) : $table;
-        }, $this->getDataTables());
+        $extraTables = array_map(fn ($table) => $table instanceof \Closure ? $table($inspector) : $table, $this->getDataTables());
         $vars["tables"] = array_merge($extraTables, $vars["tables"]);
 
         $plainTextHandler = new PlainTextHandler();

--- a/src/Whoops/Resources/views/frame_code.html.php
+++ b/src/Whoops/Resources/views/frame_code.html.php
@@ -25,7 +25,7 @@
 
           // getFileLines can return null if there is no source code
           if ($range):
-            $range = array_map(function ($line) { return empty($line) ? ' ' : $line;}, $range);
+            $range = array_map(fn ($line) => empty($line) ? ' ' : $line, $range);
             $start = key($range) + 1;
             $code  = join("\n", $range);
         ?>


### PR DESCRIPTION
Anonymous functions with one-liner return statement must use arrow functions.