### PR TITLE
No short bool cast

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -253,7 +253,7 @@ class PrettyPageHandler extends Handler
             "previousCodes"    => $inspector->getPreviousExceptionCodes(),
             "plain_exception"  => Formatter::formatExceptionPlain($inspector),
             "frames"           => $frames,
-            "has_frames"       => !!count($frames),
+            "has_frames"       => (bool)count($frames),
             "handler"          => $this,
             "handlers"         => $this->getRun()->getHandlers(),
 


### PR DESCRIPTION
Short cast bool using double exclamation mark should not be used.