### PR TITLE
Php unit expectation

### DIFF
--- a/tests/Whoops/TestCase.php
+++ b/tests/Whoops/TestCase.php
@@ -30,7 +30,7 @@ class TestCase extends BaseTestCase
         if (method_exists($this, 'expectException')) {
             $this->expectException($class);
         } else {
-            $this->setExpectedException($class);
+            $this->expectException($class);
         }
     }
 


### PR DESCRIPTION
Usages of ->setExpectedException* methods MUST be replaced by ->expectException* methods.