### PR TITLE
Removed unnecessary phpdoc param tags

### DIFF
--- a/src/Whoops/Exception/Frame.php
+++ b/src/Whoops/Exception/Frame.php
@@ -31,9 +31,6 @@ class Frame implements Serializable
      */
     protected $application;
 
-    /**
-     * @param array[]
-     */
     public function __construct(array $frame)
     {
         $this->frame = $frame;

--- a/src/Whoops/Exception/FrameCollection.php
+++ b/src/Whoops/Exception/FrameCollection.php
@@ -25,9 +25,6 @@ class FrameCollection implements ArrayAccess, IteratorAggregate, Serializable, C
      */
     private $frames;
 
-    /**
-     * @param array $frames
-     */
     public function __construct(array $frames)
     {
         $this->frames = array_map(function ($frame) {

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -301,7 +301,6 @@ class Inspector
      * Determine if the frame can be used to fill in previous frame's missing info
      * happens for call_user_func and call_user_func_array usages (PHP Bug #44428)
      *
-     * @param array $frame
      * @return bool
      */
     protected function isValidNextFrame(array $frame)

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -753,12 +753,10 @@ class PrettyPageHandler extends Handler
 
     /**
      * Set the application paths.
-     *
-     * @param array $applicationPaths
-     *
+     * 
      * @return void
      */
-    public function setApplicationPaths($applicationPaths)
+    public function setApplicationPaths(array $applicationPaths)
     {
         $this->applicationPaths = $applicationPaths;
     }

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -353,7 +353,6 @@ class PrettyPageHandler extends Handler
      * will be flattened with `print_r`.
      *
      * @param string $label
-     * @param array  $data
      *
      * @return static
      */

--- a/src/Whoops/Util/TemplateHelper.php
+++ b/src/Whoops/Util/TemplateHelper.php
@@ -232,7 +232,6 @@ class TemplateHelper
      * passed to the template.
      *
      * @param string $template
-     * @param array  $additionalVariables
      */
     public function render($template, array $additionalVariables = null)
     {
@@ -254,8 +253,6 @@ class TemplateHelper
     /**
      * Sets the variables to be passed to all templates rendered
      * by this template helper.
-     *
-     * @param array $variables
      */
     public function setVariables(array $variables)
     {


### PR DESCRIPTION
## CHANGES

* As the title says, removed many unnecessary phpdoc **param** tags (they bring no useful information).
* Added the array type declaration to the `applicationPaths` parameter for the method `\Handler\PrettyPageHandler::setApplicationPaths`  and removed the phpdoc param tag. 