### PR TITLE
Add insepctor interface + factory

### DIFF
--- a/src/Whoops/Exception/Formatter.php
+++ b/src/Whoops/Exception/Formatter.php
@@ -6,16 +6,18 @@
 
 namespace Whoops\Exception;
 
+use Whoops\Inspector\InspectorInterface;
+
 class Formatter
 {
     /**
      * Returns all basic information about the exception in a simple array
      * for further convertion to other languages
-     * @param  Inspector $inspector
+     * @param  InspectorInterface $inspector
      * @param  bool      $shouldAddTrace
      * @return array
      */
-    public static function formatExceptionAsDataArray(Inspector $inspector, $shouldAddTrace)
+    public static function formatExceptionAsDataArray(InspectorInterface $inspector, $shouldAddTrace)
     {
         $exception = $inspector->getException();
         $response = [
@@ -47,7 +49,7 @@ class Formatter
         return $response;
     }
 
-    public static function formatExceptionPlain(Inspector $inspector)
+    public static function formatExceptionPlain(InspectorInterface $inspector)
     {
         $message = $inspector->getException()->getMessage();
         $frames = $inspector->getFrames();

--- a/src/Whoops/Exception/Inspector.php
+++ b/src/Whoops/Exception/Inspector.php
@@ -6,9 +6,11 @@
 
 namespace Whoops\Exception;
 
+use Whoops\Inspector\InspectorFactory;
+use Whoops\Inspector\InspectorInterface;
 use Whoops\Util\Misc;
 
-class Inspector
+class Inspector implements InspectorInterface
 {
     /**
      * @var \Throwable
@@ -31,11 +33,18 @@ class Inspector
     private $previousExceptions;
 
     /**
-     * @param \Throwable $exception The exception to inspect
+     * @var \Whoops\Inspector\InspectorFactoryInterface|null
      */
-    public function __construct($exception)
+    protected $inspectorFactory;
+
+    /**
+     * @param \Throwable $exception The exception to inspect
+     * @param \Whoops\Inspector\InspectorFactoryInterface $factory
+     */
+    public function __construct($exception, $factory = null)
     {
         $this->exception = $exception;
+        $this->inspectorFactory = $factory ?: new InspectorFactory();
     }
 
     /**
@@ -137,7 +146,7 @@ class Inspector
             $previousException = $this->exception->getPrevious();
 
             if ($previousException) {
-                $this->previousExceptionInspector = new Inspector($previousException);
+                $this->previousExceptionInspector = $this->inspectorFactory->create($previousException);
             }
         }
 

--- a/src/Whoops/Handler/Handler.php
+++ b/src/Whoops/Handler/Handler.php
@@ -6,7 +6,7 @@
 
 namespace Whoops\Handler;
 
-use Whoops\Exception\Inspector;
+use Whoops\Inspector\InspectorInterface;
 use Whoops\RunInterface;
 
 /**
@@ -36,7 +36,7 @@ abstract class Handler implements HandlerInterface
     private $run;
 
     /**
-     * @var Inspector $inspector
+     * @var InspectorInterface $inspector
      */
     private $inspector;
 
@@ -62,15 +62,15 @@ abstract class Handler implements HandlerInterface
     }
 
     /**
-     * @param Inspector $inspector
+     * @param InspectorInterface $inspector
      */
-    public function setInspector(Inspector $inspector)
+    public function setInspector(InspectorInterface $inspector)
     {
         $this->inspector = $inspector;
     }
 
     /**
-     * @return Inspector
+     * @return InspectorInterface
      */
     protected function getInspector()
     {

--- a/src/Whoops/Handler/HandlerInterface.php
+++ b/src/Whoops/Handler/HandlerInterface.php
@@ -6,7 +6,7 @@
 
 namespace Whoops\Handler;
 
-use Whoops\Exception\Inspector;
+use Whoops\Inspector\InspectorInterface;
 use Whoops\RunInterface;
 
 interface HandlerInterface
@@ -29,8 +29,8 @@ interface HandlerInterface
     public function setException($exception);
 
     /**
-     * @param  Inspector $inspector
+     * @param  InspectorInterface $inspector
      * @return void
      */
-    public function setInspector(Inspector $inspector);
+    public function setInspector(InspectorInterface $inspector);
 }

--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -383,7 +383,7 @@ class PrettyPageHandler extends Handler
             throw new InvalidArgumentException('Expecting callback argument to be callable');
         }
 
-        $this->extraTables[$label] = function (\Whoops\Exception\Inspector $inspector = null) use ($callback) {
+        $this->extraTables[$label] = function (\Whoops\Inspector\InspectorInterface $inspector = null) use ($callback) {
             try {
                 $result = call_user_func($callback, $inspector);
 

--- a/src/Whoops/Inspector/InspectorFactory.php
+++ b/src/Whoops/Inspector/InspectorFactory.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Whoops - php errors for cool kids
+ * @author Filipe Dobreira <http://github.com/filp>
+ */
+
+namespace Whoops\Inspector;
+
+use Whoops\Exception\Inspector;
+
+class InspectorFactory implements InspectorFactoryInterface
+{
+    /**
+     * @param \Throwable $exception
+     * @return InspectorInterface
+     */
+    public function create($exception)
+    {
+        return new Inspector($exception, $this);
+    }
+}

--- a/src/Whoops/Inspector/InspectorFactoryInterface.php
+++ b/src/Whoops/Inspector/InspectorFactoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Whoops - php errors for cool kids
+ * @author Filipe Dobreira <http://github.com/filp>
+ */
+
+namespace Whoops\Inspector;
+
+interface InspectorFactoryInterface
+{
+    /**
+     * @param \Throwable $exception
+     * @return InspectorInterface
+     */
+    public function create($exception);
+}

--- a/src/Whoops/Inspector/InspectorInterface.php
+++ b/src/Whoops/Inspector/InspectorInterface.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Whoops - php errors for cool kids
+ * @author Filipe Dobreira <http://github.com/filp>
+ */
+
+namespace Whoops\Inspector;
+
+interface InspectorInterface
+{
+    /**
+     * @return \Throwable
+     */
+    public function getException();
+
+    /**
+     * @return string
+     */
+    public function getExceptionName();
+
+    /**
+     * @return string
+     */
+    public function getExceptionMessage();
+
+    /**
+     * @return string[]
+     */
+    public function getPreviousExceptionMessages();
+
+    /**
+     * @return int[]
+     */
+    public function getPreviousExceptionCodes();
+
+    /**
+     * Returns a url to the php-manual related to the underlying error - when available.
+     *
+     * @return string|null
+     */
+    public function getExceptionDocrefUrl();
+
+    /**
+     * Does the wrapped Exception has a previous Exception?
+     * @return bool
+     */
+    public function hasPreviousException();
+
+    /**
+     * Returns an Inspector for a previous Exception, if any.
+     * @todo   Clean this up a bit, cache stuff a bit better.
+     * @return InspectorInterface
+     */
+    public function getPreviousExceptionInspector();
+
+    /**
+     * Returns an array of all previous exceptions for this inspector's exception
+     * @return \Throwable[]
+     */
+    public function getPreviousExceptions();
+
+    /**
+     * Returns an iterator for the inspected exception's
+     * frames.
+     * @return \Whoops\Exception\FrameCollection
+     */
+    public function getFrames();
+}

--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -9,10 +9,13 @@ namespace Whoops;
 use InvalidArgumentException;
 use Throwable;
 use Whoops\Exception\ErrorException;
-use Whoops\Exception\Inspector;
 use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\Handler;
 use Whoops\Handler\HandlerInterface;
+use Whoops\Inspector\CallableInspectorFactory;
+use Whoops\Inspector\InspectorFactory;
+use Whoops\Inspector\InspectorFactoryInterface;
+use Whoops\Inspector\InspectorInterface;
 use Whoops\Util\Misc;
 use Whoops\Util\SystemFacade;
 
@@ -66,9 +69,17 @@ final class Run implements RunInterface
      */
     private $canThrowExceptions = true;
 
+    /**
+     * The inspector factory to create inspectors.
+     *
+     * @var InspectorFactoryInterface
+     */
+    private $inspectorFactory;
+
     public function __construct(SystemFacade $system = null)
     {
         $this->system = $system ?: new SystemFacade;
+        $this->inspectorFactory = new InspectorFactory();
     }
 
     /**
@@ -179,6 +190,7 @@ final class Run implements RunInterface
             class_exists("\\Whoops\\Exception\\FrameCollection");
             class_exists("\\Whoops\\Exception\\Frame");
             class_exists("\\Whoops\\Exception\\Inspector");
+            class_exists("\\Whoops\\Inspector\\InspectorFactory");
 
             $this->system->setErrorHandler([$this, self::ERROR_HANDLER]);
             $this->system->setExceptionHandler([$this, self::EXCEPTION_HANDLER]);
@@ -488,14 +500,26 @@ final class Run implements RunInterface
         }
     }
 
+
+    /**
+     * @param InspectorFactoryInterface $factory
+     *
+     * @return void
+     */
+    public function setInspectorFactory(InspectorFactoryInterface $factory)
+    {
+        $this->inspectorFactory = $factory;
+    }
+
+
     /**
      * @param Throwable $exception
      *
-     * @return Inspector
+     * @return InspectorInterface
      */
     private function getInspector($exception)
     {
-        return new Inspector($exception);
+        return $this->inspectorFactory->create($exception);
     }
 
     /**


### PR DESCRIPTION
This permits creation of custom inspectors within the default whoops runtime. Although inspectors are inheritable and usable with a custom runtime, this requires copy-pasting much of the runtime internals.

Primarily the goal of this is to provide one the ability to intercept traces - in particular trace rewrites for template languages (see [whoops-twig](//github.com/gwillz/whoops-twig)).

This isn't quite the same as #394 - although perhaps it might make a future revisit a bit easier.