### PR TITLE
fix(highlight): #747 Add line offset to highlight line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+* Fixed missing code highlight, which additionally led to issue with switching tabs, between application and all frames ([#747](https://github.com/filp/whoops/issues/747)).
+
 ## v2.15.1
 
 * Fixed bug with PrettyPageHandler "*Calling `getFrameFilters` method on null*" ([#751](https://github.com/filp/whoops/pull/751)).

--- a/src/Whoops/Resources/views/frame_code.html.php
+++ b/src/Whoops/Resources/views/frame_code.html.php
@@ -31,6 +31,7 @@
         ?>
             <pre class="code-block line-numbers"
               data-line="<?php echo $line ?>"
+              data-line-offset="<?php echo $start ?>"
               data-start="<?php echo $start ?>"
             ><code class="language-php"><?php echo $tpl->escape($code) ?></code></pre>
 


### PR DESCRIPTION
PrismJS sort of broken backward compatibility, while trying to improve highlight resilience[^1]. Since then it is required to add `data-line-offset` for any code, which doesn't start counting from 1, which is pretty each time, we deal with stack frames.

This commits add silently required data attribute in HTML, bringing back highlight feature and recovering from some fall through errors, raised by `TypeError` in JS execution flow (i.e. switching application and full frames tabs).

[^1]: https://github.com/PrismJS/prism/commit/9a4e725b76d22759fec58e1929450bbfe1bb6661