### PR TITLE
Speed up syntax highlighting

### DIFF
--- a/src/Whoops/Resources/js/whoops.base.js
+++ b/src/Whoops/Resources/js/whoops.base.js
@@ -25,7 +25,7 @@ Zepto(function($) {
    * highlight the current line
    */
   var renderCurrentCodeblock = function(id) {
-    Prism.highlightAll();
+    Prism.highlightAllUnder(document.querySelector('.frame-code-container .frame-code.active'));
     highlightCurrentLine();
   }
 
@@ -153,9 +153,6 @@ Zepto(function($) {
     }
   });
 
-  // Render late enough for highlightCurrentLine to be ready
-  renderCurrentCodeblock();
-
   // Avoid to quit the page with some protocol (e.g. IntelliJ Platform REST API)
   $ajaxEditors.on('click', function(e){
     e.preventDefault();
@@ -185,4 +182,7 @@ Zepto(function($) {
     e.preventDefault();
     setActiveFramesTab($(this));
   });
+
+  // Render late enough for highlightCurrentLine to be ready
+  renderCurrentCodeblock();
 });


### PR DESCRIPTION
This substantially reduces the time it takes to load a Whoops ever page, and time switching frame context.

### Error page with 96 frames, tested with Laravel
| Metric | Before PR | With PR | Improvement |
|---|---|---|---|
| Page load time | 1600ms | 900ms | +43% |
| Context switch time | 4000ms | 200ms | +95% |

This is because prior to this PR syntax highlighting occurs on page load, and every single click _for the whole page and all frames_, even those that aren't visible. This PR syntax highlights only frames that are visible.

😁