### PR TITLE
Improve link colour for link comments

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -290,13 +290,12 @@ header {
       border-radius: 6px;
       background-color: rgba(255, 255, 255, .05);
     }
-      .frame-comment a {
-        font-weight: bold;
-        text-decoration: none;
-      }
-        .frame-comment a:hover {
-          color: #4bb1b1;
-        }
+
+    .frame-comment a {
+      font-weight: bold;
+      text-decoration: underline;
+      color: #c6c6c6;
+    }
 
     .frame-comment:not(:last-child) {
       border-bottom: 1px dotted rgba(0, 0, 0, .3);


### PR DESCRIPTION
Fixes #759

Example:
<img width="1011" alt="Screenshot 2023-11-02 at 22 04 46" src="https://github.com/filp/whoops/assets/370047/49ebff91-c4f0-4da3-82fe-e32574ccc944">
