### PR TITLE
Correct vscode open links

### DIFF
--- a/src/Whoops/Handler/PrettyPageHandler.php
+++ b/src/Whoops/Handler/PrettyPageHandler.php
@@ -118,7 +118,7 @@ class PrettyPageHandler extends Handler
         "macvim"   => "mvim://open/?url=file://%file&line=%line",
         "phpstorm" => "phpstorm://open?file=%file&line=%line",
         "idea"     => "idea://open?file=%file&line=%line",
-        "vscode"   => "vscode://file/%file:%line",
+        "vscode"   => "vscode://file%file:%line",
         "atom"     => "atom://core/open/file?filename=%file&line=%line",
         "espresso" => "x-espresso://open?filepath=%file&lines=%line",
         "netbeans" => "netbeans://open/?f=%file:%line",


### PR DESCRIPTION
The format of links for vscode is currently set to:

    vscode://file/{$file}:{$line}

This leads to URIs such as:

    vscode://file//Users/example/git/example.php

However vscode expects URIs in the format:

    vscode://file/Users/example/git/example.php

That is to say that the URI should be immediately after the `file`.

The correct URI format is:

    vscode://file{$file}:{$line}

See https://github.com/microsoft/vscode/issues/197319 for more information.