### PR TITLE
Support replacing server paths to local development

### DIFF
--- a/docs/Open Files In An Editor.md
+++ b/docs/Open Files In An Editor.md
@@ -37,18 +37,22 @@ $handler->setEditor(function($file, $line) {
 
 ```
 
+If your development server is not local it's good to map remote files to local
+
+```php
+
+$handler->setEditorPathReplacements([
+    '/My/First/Server/Path'  => '~/Development/PhpStormOpener',
+    '/My/Second/Server/Path' => '~/Development/PhpStormOpener',
+]);
+
+```
+
 You can add [IntelliJ Platform](https://github.com/pinepain/PhpStormOpener#phpstormopener) support like this:
 ```php
 
 $handler->setEditor(
     function ($file, $line) {
-        // if your development server is not local it's good to map remote files to local
-        $translations = array('^' . __DIR__ => '~/Development/PhpStormOpener'); // change to your path
-
-        foreach ($translations as $from => $to) {
-            $file = preg_replace('#' . $from . '#', $to, $file, 1);
-        }
-
         // IntelliJ platform requires that you send an Ajax request, else the browser will quit the page
         return array(
             'url' => "http://localhost:63342/api/file/?file=$file&line=$line",

--- a/src/Whoops/Resources/views/frame_code.html.php
+++ b/src/Whoops/Resources/views/frame_code.html.php
@@ -10,10 +10,10 @@
           <?php if ($filePath && $editorHref = $handler->getEditorHref($filePath, (int) $line)): ?>
             <a href="<?php echo $editorHref ?>" class="editor-link"<?php echo ($handler->getEditorAjax($filePath, (int) $line) ? ' data-ajax' : '') ?>>
               Open:
-              <strong><?php echo $tpl->breakOnDelimiter('/', $tpl->escape($filePath ?: '<#unknown>')) ?></strong>
+              <strong><?php echo $tpl->breakOnDelimiter('/', $tpl->escape($handler->normalizeFilePath($filePath) ?: '<#unknown>')) ?></strong>
             </a>
           <?php else: ?>
-            <strong><?php echo $tpl->breakOnDelimiter('/', $tpl->escape($filePath ?: '<#unknown>')) ?></strong>
+            <strong><?php echo $tpl->breakOnDelimiter('/', $tpl->escape($handler->normalizeFilePath($filePath) ?: '<#unknown>')) ?></strong>
           <?php endif ?>
         </div>
         <?php


### PR DESCRIPTION
Other packages take care of making these replacements. Any reason not to do it here?

Code from
*normalizeFilePath*: [DebugBar/DataFormatter/HasXdebugLinks.php#L27-L45](https://github.com/php-debugbar/php-debugbar/blob/858720733df92af13798315b2664ba3007bec581/src/DebugBar/DataFormatter/HasXdebugLinks.php#L27-L45)
*Replacements array*: [DebugBar/DataFormatter/HasXdebugLinks.php#L176-L198](https://github.com/php-debugbar/php-debugbar/blob/858720733df92af13798315b2664ba3007bec581/src/DebugBar/DataFormatter/HasXdebugLinks.php#L176-L198)
*URL link replacement*: [DebugBar/DataFormatter/HasXdebugLinks.php#L68-L73](https://github.com/php-debugbar/php-debugbar/blob/858720733df92af13798315b2664ba3007bec581/src/DebugBar/DataFormatter/HasXdebugLinks.php#L68-L73)

I don't see any breaking change. If the array is empty, works the same as it has been until now.