### PR TITLE
Open editor from code block rows numbers

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -558,3 +558,11 @@ pre.sf-dump {
       .search-for-help li a svg path {
         background-size: contain;
       }
+
+.line-numbers-rows span {
+  pointer-events: auto;
+  cursor: pointer;
+}
+.line-numbers-rows span:hover {
+  text-decoration: underline;
+}

--- a/src/Whoops/Resources/js/whoops.base.js
+++ b/src/Whoops/Resources/js/whoops.base.js
@@ -183,6 +183,30 @@ Zepto(function($) {
     setActiveFramesTab($(this));
   });
 
+    // Open editor from code block rows number
+  $(document).delegate('.line-numbers-rows > span', 'click', function(e) {
+    var linkTag = $(this).closest('.frame-code').find('.editor-link');
+    if (!linkTag) return;
+    var editorUrl = linkTag.attr('href');
+    var requiresAjax = linkTag.data('ajax');
+
+    var lineOffset = $(this).closest('[data-line-offset]').data('line-offset');
+    var lineNumber = lineOffset + $(this).index();
+
+    var realLine = $(this).closest('[data-line]').data('line');
+    if (!realLine) return;
+    var fileUrl = editorUrl.replace(
+      new RegExp('([:=])' + realLine),
+      '$1' + lineNumber
+    );
+
+    if (requiresAjax) {
+      $.get(fileUrl);
+    } else {
+      $('<a>').attr('href', fileUrl).trigger('click');
+    }
+  });
+
   // Render late enough for highlightCurrentLine to be ready
   renderCurrentCodeblock();
 });


### PR DESCRIPTION
Clicking on any line number would open the editor at the specified line.

![image](https://github.com/user-attachments/assets/a900d11e-0007-448c-9490-026141157cb4)

--- 

maybe with a svg icon on mouse hover, I'm waiting for the review
```css
.line-numbers-rows span:hover::after,
.frame-file .editor-link:hover::after {
    content: "";
    display: inline-block;
    width: 16px;
    height: 16px;
    position: absolute;
    margin-left: 1px;
    margin-top: -20px;
    background-color: currentColor;
    -webkit-mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 21v-3.75L16.88 3.37a1.75 1.75 0 0 1 2.47 0l1.28 1.28a1.75 1.75 0 0 1 0 2.47L6.75 21H3zm2-1h1.75l11.5-11.5-1.75-1.75L5 18.25V20z"/></svg>');
    mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M3 21v-3.75L16.88 3.37a1.75 1.75 0 0 1 2.47 0l1.28 1.28a1.75 1.75 0 0 1 0 2.47L6.75 21H3zm2-1h1.75l11.5-11.5-1.75-1.75L5 18.25V20z"/></svg>');
}
.frame-file .editor-link:hover::after {
    margin-top: -1px;
    margin-left: 5px;
}
```
![image](https://github.com/user-attachments/assets/ab144911-de19-4ab6-82b9-23b7a5ce2b81)
![image](https://github.com/user-attachments/assets/9fc60a73-c94c-4a98-aa0d-ef67d1c3c5cf)

