### PR TITLE
Disable shutdown function when not registered

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -507,6 +507,11 @@ final class Run implements RunInterface
         // to the exception handler. Pass that information along.
         $this->canThrowExceptions = false;
 
+        // If we are not currently registered, we should not do anything
+        if (!$this->isRegistered) {
+            return;
+        }
+
         $error = $this->system->getLastError();
         if ($error && Misc::isLevelFatal($error['type'])) {
             // If there was a fatal error,

--- a/tests/Whoops/RunTest.php
+++ b/tests/Whoops/RunTest.php
@@ -12,7 +12,10 @@ use InvalidArgumentException;
 use Mockery as m;
 use RuntimeException;
 use Whoops\Handler\Handler;
+use Whoops\Handler\HandlerInterface;
+use Whoops\Handler\PrettyPageHandler;
 use Whoops\Exception\Frame;
+use Whoops\Util\SystemFacade;
 
 class RunTest extends TestCase
 {
@@ -570,5 +573,37 @@ class RunTest extends TestCase
 
         $this->assertEmpty($run->getFrameFilters());
         $this->assertInstanceOf("Whoops\\RunInterface", $run);
+    }
+
+    public function testShutdownHandlerDoesNotRunIfUnregistered()
+    {
+        $system = m::mock('Whoops\Util\SystemFacade');
+
+        $run = new Run($system);
+        $run->writeToOutput(false);
+        $run->allowQuit(false);
+
+        $fatalError = [
+            'type'    => E_ERROR,
+            'message' => 'Simulated fatal error for shutdown',
+            'file'    => 'somefile.php',
+            'line'    => 10,
+        ];
+        $system->shouldReceive('getLastError')->andReturn($fatalError)->byDefault();
+
+        $mockHandler = m::mock('Whoops\Handler\HandlerInterface');
+        $mockHandler->shouldNotReceive('handle');
+        $mockHandler->shouldNotReceive('setRun');
+        $mockHandler->shouldNotReceive('setInspector');
+        $mockHandler->shouldNotReceive('setException');
+        $run->pushHandler($mockHandler);
+
+        $run->unregister();
+
+        ob_start();
+        $run->handleShutdown();
+        $output = ob_get_clean();
+
+        $this->assertEquals('', $output, "Output buffer should be empty.");
     }
 }


### PR DESCRIPTION
A proposed fix for #772. We cannot unregister a shutdown function, but we can just make it do nothing. By checking the `isRegistered` property we can determine whether the shutdown function is supposed to be run at this time.

Still needs a few tests; presumably by calling the shutdown function and checking it does nothing when the instance is no longer registered.