### PR TITLE
Prevent javascript error: `TypeError: can't access property "scrollIntoView", line is undefined`

### DIFF
--- a/src/Whoops/Resources/js/whoops.base.js
+++ b/src/Whoops/Resources/js/whoops.base.js
@@ -43,8 +43,11 @@ Zepto(function($) {
     });
 
     var line = $activeFrame.find('.code-block .line-highlight').first()[0];
-    line.scrollIntoView();
-    line.parentElement.scrollTop -= 180;
+    // [internal] frames might not contain a code-block
+    if (line) {
+      line.scrollIntoView();
+      line.parentElement.scrollTop -= 180;
+    }
 
     $container.scrollTop(0);
   }


### PR DESCRIPTION
when navigating to a "[internal]" frame, no code block is rendered:

<img width="802" alt="grafik" src="https://github.com/user-attachments/assets/f0476ad1-0a7b-4a96-becb-561add959d30" />

lets not assume in our javascript a code-block is always present.