### PR TITLE
CI: use ubuntu 22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
Use slightly newer ubuntu version to make CI work again.
I don't not make it even newer, as I think we cannot support PHP 7.1 on newer ubuntu