### PR TITLE
Unregister/cleanup handler on destroy

### DIFF
--- a/src/Whoops/Run.php
+++ b/src/Whoops/Run.php
@@ -87,6 +87,11 @@ final class Run implements RunInterface
         $this->inspectorFactory = new InspectorFactory();
     }
 
+    public function __destruct()
+    {
+        $this->unregister();
+    }
+
     /**
      * Explicitly request your handler runs as the last of all currently registered handlers.
      *
@@ -531,7 +536,7 @@ final class Run implements RunInterface
     {
         if (!is_callable($filterCallback)) {
             throw new \InvalidArgumentException(sprintf(
-                "A frame filter must be of type callable, %s type given.", 
+                "A frame filter must be of type callable, %s type given.",
                 gettype($filterCallback)
             ));
         }


### PR DESCRIPTION
This PR ensures that the Run class unregisters itself if its destroyed (needed for longer running processes)