### PR TITLE
Mention PHPStorm URL Handler for Linux

### DIFF
--- a/docs/Open Files In An Editor.md
+++ b/docs/Open Files In An Editor.md
@@ -18,7 +18,7 @@ The following editors are currently supported by default.
 - `emacs`    - Emacs
 - `idea`     - IDEA
 - `macvim`   - MacVim
-- `phpstorm` - PhpStorm
+- `phpstorm` - PhpStorm (on Linux you might need to manually install a [handler](https://github.com/sanduhrs/phpstorm-url-handler))
 - `sublime`  - Sublime Text 2 and possibly 3 (on OS X you might need [a special handler](https://github.com/inopinatus/sublime_url))
 - `textmate` - Textmate
 - `xdebug`   - xdebug (uses [xdebug.file_link_format](http://xdebug.org/docs/all_settings#file_link_format))


### PR DESCRIPTION
I found out via Perplexity why these handlers never really worked in my case (Linux Mint 21), even though it seemed to call PHPStorm from Vivaldi.

With that handler, it started (trying) to open the file on my IDE. Then, all that was left was write the custom handler to translate Docker paths into local ones (without the translating code, it just opens an empty file with the correct name lol)

Thanks for Whoops, sir!