### PR TITLE
Fix constant E_STRICT deprecation warning when running tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,8 +3,8 @@
  * Whoops - php errors for cool kids
  * @author Filipe Dobreira <http://github.com/filp>
  *
- * Bootstraper for PHPUnit tests.
+ * Bootstrapper for PHPUnit tests.
  */
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Fix constant E_STRICT deprecation warning when running tests on PHP >= 8.4:

```
$ vendor/bin/phpunit -c phpunit.xml.dist
PHP Deprecated:  Constant E_STRICT is deprecated in whoops/tests/bootstrap.php on line 8
```