### PR TITLE
Fix PHP 8.5 deprecation when casting to integer using the non canonical name

### DIFF
--- a/src/Whoops/Handler/PlainTextHandler.php
+++ b/src/Whoops/Handler/PlainTextHandler.php
@@ -159,12 +159,12 @@ class PlainTextHandler extends Handler
      * Set the size limit in bytes of frame arguments var_dump output.
      * If the limit is reached, the var_dump output is discarded.
      * Prevent memory limit errors.
-     * @var integer
+     * @param int $traceFunctionArgsOutputLimit
      * @return static
      */
     public function setTraceFunctionArgsOutputLimit($traceFunctionArgsOutputLimit)
     {
-        $this->traceFunctionArgsOutputLimit = (integer) $traceFunctionArgsOutputLimit;
+        $this->traceFunctionArgsOutputLimit = (int) $traceFunctionArgsOutputLimit;
         return $this;
     }
 


### PR DESCRIPTION
In PHP 8.5, casting to integer|boolean|double|binary is deprecated, and int|bool|float|string should be used instead. This fixes a cast to (integer) which is deprecated. See also: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_non-standard_cast_names

I know it's quite early (PHP 8.5 is not yet released) but the RFC was accepted so I figured what better time than now :-) This will work with all currently supported versions of PHP too