### PR TITLE
feat: allow symfony/var-dumper 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.3 || ^10.5.58",
         "mockery/mockery": "^1.0",
-        "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "suggest": {
         "symfony/var-dumper": "Pretty print complex values better with var-dumper available",


### PR DESCRIPTION
Symfony 8 is released today.

Covered by PHP 8.4 and 8.5 runs in the ci
https://github.com/filp/whoops/actions/runs/19733518233/job/56539913057?pr=788