### PR TITLE
Integration of Whoops into the ZubZet framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ powerful stacked error handling system.
 <a href="https://blackfire.io/docs/introduction?utm_source=whoops&amp;utm_medium=github_readme&amp;utm_campaign=logo"><img src="https://i.imgur.com/zR8rsqk.png" alt="Blackfire.io" width="254" height="64"></a>
 
 ## Installing
-If you use Laravel 4, Laravel 5.5+ or [Mezzio](https://docs.mezzio.dev/mezzio/), you already have Whoops. There are also community-provided instructions on how to integrate Whoops into
+If you use Laravel 4, Laravel 5.5+, [Mezzio](https://docs.mezzio.dev/mezzio/) or [ZubZet 1.2+](https://zubzet.com/), you already have Whoops. There are also community-provided instructions on how to integrate Whoops into
 [Silex 1](https://github.com/whoops-php/silex-1),
 [Silex 2](https://github.com/texthtml/whoops-silex),
 [Phalcon](https://github.com/whoops-php/phalcon),


### PR DESCRIPTION
Add a link to the [ZubZet framework](https://github.com/zubzet/framework) in the README. 

Regarding: https://github.com/filp/whoops/blob/master/docs/Framework%20Integration.md

Starting with version 1.2.0 we have finally integrated Whoops. It is automatically included with each installation dev environment and does not require a bridge to also be installed.

If you are interested in the implementation, check out the [namespace](https://github.com/qtNoe/fork-from-framework/tree/bb24413e70c92d5c88814e0705ad8579aa5960fc/src/ErrorHandling) for it.

The PR for it: https://github.com/zubzet/framework/pull/136

Looking forward to implementing more!