### PR TITLE
Add `.mailmap` to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@ tests/ export-ignore
 phpunit.xml.dist export-ignore
 CONTRIBUTING.md export-ignore
 README.md export-ignore
+.mailmap export-ignore


### PR DESCRIPTION
Current archive targets other than src/ will be as follows:
```bash
gh api repos/filp/whoops/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
CHANGELOG.md
composer.json
LICENSE.md
.mailmap
SECURITY.md
```

With this PR, the archive targets other than src/ will be as follows:
```bash
gh api repos/sasezaki/whoops/tarball/patch-gitattributes | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
CHANGELOG.md
composer.json
LICENSE.md
SECURITY.md
```

Changes:
- Added `.mailmap export-ignore`
  - `.mailmap`: A Git-specific author-identity mapping file (used by `git shortlog` etc.); has no relevance outside the repository and is not needed by package consumers.
